### PR TITLE
Cancel regular unmount if filesystem is still in use

### DIFF
--- a/src/main/java/org/cryptomator/frontend/fuse/FuseNioAdapter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/FuseNioAdapter.java
@@ -7,17 +7,16 @@ public interface FuseNioAdapter extends FuseFS, AutoCloseable {
 	boolean isMounted();
 
 	/**
-	 * Checks if it is not safe to unmount this filesystemin.
-	 *
-	 * Important: This function only checks if it is _not_ safe and a return value of {@code false} should not be considered as an unmount can be safely executed.
-	 * The file system may be in state where it cannot be determined, hence this method returns false.
-	 *
-	 * API note: It is the task of the fs developer to decide what "not safe" means. For example, "not safe" can mean there are open resources or pending operations.
+	 * Checks if the filesystem is in use (and therefore an unmount attempt should be avoided).
+	 * <p>
+	 * Important: This function only checks, like the name suggests, if the filesystem is busy and used. A return value of {@code false} should not be considered as an unmount can be safely and successfully executed and thus an unmount may fail.
+	 * <p>
+	 * API note: It is the task of the fs developer to decide what "in use" means. For example, "in use" can mean there are open resources or pending operations.
 	 * Additionally no guarantees about the validity of the result after the call is made, i.e. the result may be immediately outdated.
 	 *
-	 * @return true if the filesystem is in a state, where an unmount should not be performed.
+	 * @return true if the filesystem is in use
 	 */
-	boolean isNotSafeToUnmount();
+	boolean isInUse();
 
 	/**
 	 * Sets mounted to false.

--- a/src/main/java/org/cryptomator/frontend/fuse/FuseNioAdapter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/FuseNioAdapter.java
@@ -7,6 +7,19 @@ public interface FuseNioAdapter extends FuseFS, AutoCloseable {
 	boolean isMounted();
 
 	/**
+	 * Checks if it is not safe to unmount this filesystemin.
+	 *
+	 * Important: This function only checks if it is _not_ safe and a return value of {@code false} should not be considered as an unmount can be safely executed.
+	 * The file system may be in state where it cannot be determined, hence this method returns false.
+	 *
+	 * API note: It is the task of the fs developer to decide what "not safe" means. For example, "not safe" can mean there are open resources or pending operations.
+	 * Additionally no guarantees about the validity of the result after the call is made, i.e. the result may be immediately outdated.
+	 *
+	 * @return true if the filesystem is in a state, where an unmount should not be performed.
+	 */
+	boolean isNotSafeToUnmount();
+
+	/**
 	 * Sets mounted to false.
 	 * <p>
 	 * Allows custom unmount implementations to prevent subsequent invocations of {@link #umount()} to run into illegal states.

--- a/src/main/java/org/cryptomator/frontend/fuse/OpenFileFactory.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/OpenFileFactory.java
@@ -81,6 +81,10 @@ public class OpenFileFactory implements AutoCloseable {
 		}
 	}
 
+	public int getOpenFileCount(){
+		return openFiles.size();
+	}
+
 	/**
 	 * Closes all currently open files.
 	 * Calling this method will not prevent the factory to open new files, i.e. this method can be called multiple times and is not idempotent.

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
@@ -263,7 +263,7 @@ public class ReadOnlyAdapter extends FuseStubFS implements FuseNioAdapter {
 	}
 
 	@Override
-	public boolean isNotSafeToUnmount() {
+	public boolean isInUse() {
 		try (PathLock pLock = lockManager.createPathLock("/").tryForWriting()) {
 			return hasOpenFiles.getAsBoolean();
 		} catch (AlreadyLockedException e) {

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Iterables;
 import jnr.ffi.Pointer;
 import jnr.ffi.types.off_t;
 import jnr.ffi.types.size_t;
+import org.cryptomator.frontend.fuse.locks.AlreadyLockedException;
 import org.cryptomator.frontend.fuse.locks.DataLock;
 import org.cryptomator.frontend.fuse.locks.LockManager;
 import org.cryptomator.frontend.fuse.locks.PathLock;
@@ -38,6 +39,7 @@ import java.nio.file.attribute.PosixFileAttributes;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
+import java.util.function.BooleanSupplier;
 
 /**
  * Read-Only FUSE-NIO-Adapter based on Sergey Tselovalnikov's <a href="https://github.com/SerCeMan/jnr-fuse/blob/0.5.1/src/main/java/ru/serce/jnrfuse/examples/HelloFuse.java">HelloFuse</a>
@@ -55,9 +57,10 @@ public class ReadOnlyAdapter extends FuseStubFS implements FuseNioAdapter {
 	private final ReadOnlyFileHandler fileHandler;
 	private final ReadOnlyLinkHandler linkHandler;
 	private final FileAttributesUtil attrUtil;
+	private final BooleanSupplier hasOpenFiles;
 
 	@Inject
-	public ReadOnlyAdapter(@Named("root") Path root, @Named("maxFileNameLength") int maxFileNameLength, FileStore fileStore, LockManager lockManager, ReadOnlyDirectoryHandler dirHandler, ReadOnlyFileHandler fileHandler, ReadOnlyLinkHandler linkHandler, FileAttributesUtil attrUtil) {
+	public ReadOnlyAdapter(@Named("root") Path root, @Named("maxFileNameLength") int maxFileNameLength, FileStore fileStore, LockManager lockManager, ReadOnlyDirectoryHandler dirHandler, ReadOnlyFileHandler fileHandler, ReadOnlyLinkHandler linkHandler, FileAttributesUtil attrUtil, OpenFileFactory fileFactory) {
 		this.root = root;
 		this.maxFileNameLength = maxFileNameLength;
 		this.fileStore = fileStore;
@@ -66,6 +69,7 @@ public class ReadOnlyAdapter extends FuseStubFS implements FuseNioAdapter {
 		this.fileHandler = fileHandler;
 		this.linkHandler = linkHandler;
 		this.attrUtil = attrUtil;
+		this.hasOpenFiles = () -> fileFactory.getOpenFileCount() != 0;
 	}
 
 	protected Path resolvePath(String absolutePath) {
@@ -259,6 +263,15 @@ public class ReadOnlyAdapter extends FuseStubFS implements FuseNioAdapter {
 	}
 
 	@Override
+	public boolean isNotSafeToUnmount() {
+		try (PathLock pLock = lockManager.createPathLock("/").tryForWriting()) {
+			return hasOpenFiles.getAsBoolean();
+		} catch (AlreadyLockedException e) {
+			return true;
+		}
+	}
+
+	@Override
 	public void setUnmounted() {
 		if (mounted.compareAndSet(true, false)) {
 			LOG.debug("Marked file system adapter as unmounted.");
@@ -276,7 +289,7 @@ public class ReadOnlyAdapter extends FuseStubFS implements FuseNioAdapter {
 	 * Attempts to get a specific error code that best describes the given exception.
 	 * As a side effect this logs the error.
 	 *
-	 * @param e      An exception
+	 * @param e An exception
 	 * @param opDesc A human-friendly string describing what operation was attempted (for logging purposes)
 	 * @return A specific error code or -EIO.
 	 */

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadWriteAdapter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadWriteAdapter.java
@@ -51,8 +51,8 @@ public class ReadWriteAdapter extends ReadOnlyAdapter {
 	private final BitMaskEnumUtil bitMaskUtil;
 
 	@Inject
-	public ReadWriteAdapter(@Named("root") Path root, @Named("maxFileNameLength") int maxFileNameLength, FileStore fileStore, LockManager lockManager, ReadWriteDirectoryHandler dirHandler, ReadWriteFileHandler fileHandler, ReadOnlyLinkHandler linkHandler, FileAttributesUtil attrUtil, BitMaskEnumUtil bitMaskUtil) {
-		super(root, maxFileNameLength, fileStore, lockManager, dirHandler, fileHandler, linkHandler, attrUtil);
+	public ReadWriteAdapter(@Named("root") Path root, @Named("maxFileNameLength") int maxFileNameLength, FileStore fileStore, LockManager lockManager, ReadWriteDirectoryHandler dirHandler, ReadWriteFileHandler fileHandler, ReadOnlyLinkHandler linkHandler, FileAttributesUtil attrUtil, BitMaskEnumUtil bitMaskUtil, OpenFileFactory fileFactory) {
+		super(root, maxFileNameLength, fileStore, lockManager, dirHandler, fileHandler, linkHandler, attrUtil, fileFactory);
 		this.fileHandler = fileHandler;
 		this.attrUtil = attrUtil;
 		this.bitMaskUtil = bitMaskUtil;

--- a/src/main/java/org/cryptomator/frontend/fuse/locks/AlreadyLockedException.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/locks/AlreadyLockedException.java
@@ -1,0 +1,8 @@
+package org.cryptomator.frontend.fuse.locks;
+
+public class AlreadyLockedException extends Exception {
+
+	public AlreadyLockedException(){
+		super();
+	}
+}

--- a/src/main/java/org/cryptomator/frontend/fuse/locks/PathLockBuilder.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/locks/PathLockBuilder.java
@@ -4,6 +4,10 @@ public interface PathLockBuilder {
 
 	PathLock forReading();
 
+	PathLock tryForReading() throws AlreadyLockedException;
+
 	PathLock forWriting();
+
+	PathLock tryForWriting() throws AlreadyLockedException;
 
 }

--- a/src/main/java/org/cryptomator/frontend/fuse/locks/PathLockBuilderImpl.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/locks/PathLockBuilderImpl.java
@@ -24,9 +24,19 @@ class PathLockBuilderImpl implements PathLockBuilder {
 		return PathRLockImpl.create(pathComponents, parentLock, lock, dataLockSupplier);
 	}
 
+	public PathLock tryForReading() throws AlreadyLockedException {
+		Optional<PathLock> parentLock = parent.map(PathLockBuilder::forReading);
+		return PathRLockImpl.attempt(pathComponents, parentLock, lock, dataLockSupplier);
+	}
+
 	public PathLock forWriting() {
 		Optional<PathLock> parentLock = parent.map(PathLockBuilder::forReading);
 		return PathWLockImpl.create(pathComponents, parentLock, lock, dataLockSupplier);
+	}
+
+	public PathLock tryForWriting() throws AlreadyLockedException {
+		Optional<PathLock> parentLock = parent.map(PathLockBuilder::forReading);
+		return PathWLockImpl.attempt(pathComponents, parentLock, lock, dataLockSupplier);
 	}
 
 }

--- a/src/main/java/org/cryptomator/frontend/fuse/locks/PathRLockImpl.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/locks/PathRLockImpl.java
@@ -22,6 +22,14 @@ class PathRLockImpl extends PathLockImpl {
 		return new PathRLockImpl(pathComponents, parent, lock, dataLockSupplier);
 	}
 
+	public static PathLockImpl attempt(List<String> pathComponents, Optional<PathLock> parent, ReadWriteLock lock, Function<List<String>, ReadWriteLock> dataLockSupplier) throws AlreadyLockedException {
+		if (!lock.readLock().tryLock()) {
+			throw new AlreadyLockedException();
+		}
+		LOG.trace("Acquired read path lock for '{}'", pathComponents);
+		return new PathRLockImpl(pathComponents, parent, lock, dataLockSupplier);
+	}
+
 	@Override
 	public void close() {
 		LOG.trace("Released read path lock for '{}'", pathComponents);

--- a/src/main/java/org/cryptomator/frontend/fuse/locks/PathWLockImpl.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/locks/PathWLockImpl.java
@@ -22,6 +22,14 @@ class PathWLockImpl extends PathLockImpl {
 		return new PathWLockImpl(pathComponents, parent, lock, dataLockSupplier);
 	}
 
+	public static PathLockImpl attempt(List<String> pathComponents, Optional<PathLock> parent, ReadWriteLock lock, Function<List<String>, ReadWriteLock> dataLockSupplier) throws AlreadyLockedException {
+		if (!lock.writeLock().tryLock()) {
+			throw new AlreadyLockedException();
+		}
+		LOG.trace("Acquired write path lock for '{}'", pathComponents);
+		return new PathWLockImpl(pathComponents, parent, lock, dataLockSupplier);
+	}
+
 	@Override
 	public void close() {
 		LOG.trace("Released write path lock for '{}'", pathComponents);

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/AbstractMount.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/AbstractMount.java
@@ -39,7 +39,7 @@ abstract class AbstractMount implements Mount {
 
 	@Override
 	public void unmount() throws CommandFailedException {
-		if (fuseAdapter.isNotSafeToUnmount()) {
+		if (fuseAdapter.isInUse()) {
 			throw new CommandFailedException("Unmount refused: There are open files or pending operations.");
 		}
 

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/AbstractMount.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/AbstractMount.java
@@ -38,6 +38,24 @@ abstract class AbstractMount implements Mount {
 	}
 
 	@Override
+	public void unmount() throws CommandFailedException {
+		if (fuseAdapter.isNotSafeToUnmount()) {
+			throw new CommandFailedException("Unmount refused: There are open files or pending operations.");
+		}
+
+		unmountInternal();
+	}
+
+	@Override
+	public void unmountForced() throws CommandFailedException {
+		unmountForcedInternal();
+	}
+
+	protected abstract void unmountInternal() throws CommandFailedException;
+
+	protected abstract void unmountForcedInternal() throws CommandFailedException;
+
+	@Override
 	public void close() throws CommandFailedException {
 		if (this.fuseAdapter.isMounted()) {
 			throw new IllegalStateException("Can not close file system adapter while still mounted.");

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/LinuxMounter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/LinuxMounter.java
@@ -72,7 +72,7 @@ class LinuxMounter implements Mounter {
 		}
 
 		@Override
-		public void unmount() throws CommandFailedException {
+		public void unmountInternal() throws CommandFailedException {
 			if (!fuseAdapter.isMounted()) {
 				return;
 			}
@@ -84,7 +84,7 @@ class LinuxMounter implements Mounter {
 		}
 
 		@Override
-		public void unmountForced() throws CommandFailedException {
+		public void unmountForcedInternal() throws CommandFailedException {
 			if (!fuseAdapter.isMounted()) {
 				return;
 			}

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/MacMounter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/MacMounter.java
@@ -144,7 +144,7 @@ class MacMounter implements Mounter {
 		}
 
 		@Override
-		public void unmount() throws CommandFailedException {
+		public void unmountInternal() throws CommandFailedException {
 			if (!fuseAdapter.isMounted()) {
 				return;
 			}
@@ -156,7 +156,7 @@ class MacMounter implements Mounter {
 		}
 
 		@Override
-		public void unmountForced() throws CommandFailedException {
+		public void unmountForcedInternal() throws CommandFailedException {
 			if (!fuseAdapter.isMounted()) {
 				return;
 			}

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/WindowsMounter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/WindowsMounter.java
@@ -54,7 +54,7 @@ class WindowsMounter implements Mounter {
 		}
 
 		@Override
-		public void unmount() {
+		protected void unmountInternal() {
 			if (!fuseAdapter.isMounted()) {
 				return;
 			}
@@ -62,8 +62,8 @@ class WindowsMounter implements Mounter {
 		}
 
 		@Override
-		public void unmountForced() {
-			unmount();
+		protected void unmountForcedInternal() {
+			unmountInternal();
 		}
 
 	}

--- a/src/test/java/org/cryptomator/frontend/fuse/locks/LockManagerTest.java
+++ b/src/test/java/org/cryptomator/frontend/fuse/locks/LockManagerTest.java
@@ -129,7 +129,7 @@ public class LockManagerTest {
 
 		@Test
 		@DisplayName("try-Methods fail with exception if path already locked for writing")
-		public void testTryForWritingMethod() {
+		public void testTryForMethodsOnWriteLock() {
 			LockManager lockManager = new LockManager();
 			ExecutorService threadPool = Executors.newFixedThreadPool(1);
 			CountDownLatch done = new CountDownLatch(1);
@@ -162,7 +162,7 @@ public class LockManagerTest {
 
 		@Test
 		@DisplayName("try-Methods partially fail with exception if path already locked for reading")
-		public void testTryForReadingMethod() {
+		public void testTryForMethodsOnReadLock() {
 			LockManager lockManager = new LockManager();
 			ExecutorService threadPool = Executors.newFixedThreadPool(1);
 			CountDownLatch done = new CountDownLatch(1);

--- a/src/test/java/org/cryptomator/frontend/fuse/locks/LockManagerTest.java
+++ b/src/test/java/org/cryptomator/frontend/fuse/locks/LockManagerTest.java
@@ -131,50 +131,34 @@ public class LockManagerTest {
 		@DisplayName("try-Methods fail with exception if path already locked")
 		public void testTryMethod() {
 			LockManager lockManager = new LockManager();
-			int numThreads = 4;
-			ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
-			CountDownLatch done = new CountDownLatch(numThreads);
-			AtomicInteger counter = new AtomicInteger();
-			AtomicInteger maxCounter = new AtomicInteger();
+			ExecutorService threadPool = Executors.newFixedThreadPool(2);
+			CountDownLatch done = new CountDownLatch(2);
 			AtomicInteger exceptionCounter = new AtomicInteger();
 
 			try (PathLock lock = lockManager.createPathLock("/foo/bar/baz").forWriting()) {
-				for (int i = 0; i < numThreads; i++) {
-					int threadnum = i;
-					threadPool.submit(() -> {
-						if (threadnum % 2 == 0) {
-							try (PathLock lockThread = lockManager.createPathLock("/foo/bar/baz").tryForWriting()) {
-								counter.incrementAndGet();
-								Thread.sleep(10);
-								maxCounter.set(Math.max(counter.get(), maxCounter.get()));
-								counter.decrementAndGet();
-							} catch (InterruptedException e) {
-								LOG.error("thread interrupted", e);
-							} catch (AlreadyLockedException e) {
-								exceptionCounter.incrementAndGet();
-							}
-						} else {
-							try (PathLock lockThread = lockManager.createPathLock("/foo/bar/baz").tryForReading()) {
-								counter.incrementAndGet();
-								Thread.sleep(10);
-								maxCounter.set(Math.max(counter.get(), maxCounter.get()));
-								counter.decrementAndGet();
-							} catch (InterruptedException e) {
-								LOG.error("thread interrupted", e);
-							} catch (AlreadyLockedException e) {
-								exceptionCounter.incrementAndGet();
-							}
-						}
-						done.countDown();
-					});
-				}
+				threadPool.submit(() -> {
+					try (PathLock lockThread = lockManager.createPathLock("/foo/bar/baz").tryForWriting()) {
+						//do nuthin'
+					} catch (AlreadyLockedException e) {
+						exceptionCounter.incrementAndGet();
+					}
+					done.countDown();
+				});
+				threadPool.submit(() -> {
+					try (PathLock lockThread = lockManager.createPathLock("/foo/bar/baz").tryForReading()) {
+						//do nuthin'
+					} catch (AlreadyLockedException e) {
+						exceptionCounter.incrementAndGet();
+					}
+					done.countDown();
+				});
+
 				Assertions.assertTimeoutPreemptively(Duration.ofSeconds(10), () -> { // deadlock protection
 					done.await();
 				});
 			}
 
-			Assertions.assertEquals(0, maxCounter.get());
-			Assertions.assertEquals(4, exceptionCounter.get());
+			Assertions.assertEquals(2, exceptionCounter.get());
 		}
 
 	}

--- a/src/test/java/org/cryptomator/frontend/fuse/locks/LockManagerTest.java
+++ b/src/test/java/org/cryptomator/frontend/fuse/locks/LockManagerTest.java
@@ -151,7 +151,7 @@ public class LockManagerTest {
 					done.countDown();
 				});
 
-				Assertions.assertTimeoutPreemptively(Duration.ofSeconds(10), () -> { // deadlock protection
+				Assertions.assertTimeoutPreemptively(Duration.ofSeconds(3), () -> { // deadlock protection
 					done.await();
 				});
 			}
@@ -184,7 +184,7 @@ public class LockManagerTest {
 					done.countDown();
 				});
 
-				Assertions.assertTimeoutPreemptively(Duration.ofSeconds(10), () -> { // deadlock protection
+				Assertions.assertTimeoutPreemptively(Duration.ofSeconds(3), () -> { // deadlock protection
 					done.await();
 				});
 			}

--- a/src/test/java/org/cryptomator/frontend/fuse/mount/MirroringFuseMountTest.java
+++ b/src/test/java/org/cryptomator/frontend/fuse/mount/MirroringFuseMountTest.java
@@ -186,7 +186,13 @@ public class MirroringFuseMountTest {
 			LOG.info("Mounted successfully. Enter anything to stop the server...");
 			mnt.revealInFileManager();
 			System.in.read();
-			mnt.unmountForced();
+			try {
+				mnt.unmount();
+			} catch (CommandFailedException e) {
+				LOG.info("Unable to perform regular unmount.", e);
+				LOG.info("Forcing unmount...");
+				mnt.unmountForced();
+			}
 			LOG.info("Unmounted successfully. Exiting...");
 		} catch (IOException | CommandFailedException e) {
 			LOG.error("Mount failed", e);


### PR DESCRIPTION
This PR closes #47.

It adds the method `isNotSafeToUnmount()` to `FuseNioAdapter`, to indicate wether the filesystem is in a state where the (internal) regular unmount method should be called.

To achieve this, the number of open files is checked and wether there is a pending (path locking) file system operation.