### PR TITLE
Feature/#56 encoding adapter

### DIFF
--- a/src/main/java/org/cryptomator/frontend/fuse/AdapterFactory.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/AdapterFactory.java
@@ -1,5 +1,8 @@
 package org.cryptomator.frontend.fuse;
 
+import org.cryptomator.frontend.fuse.encoding.BufferEncoder;
+import org.cryptomator.frontend.fuse.encoding.DefaultEncoder;
+
 import java.nio.file.Path;
 
 public class AdapterFactory {
@@ -23,7 +26,12 @@ public class AdapterFactory {
 	}
 
 	public static FuseNioAdapter createReadWriteAdapter(Path root, int maxFileNameLength) {
-		FuseNioAdapterComponent comp = DaggerFuseNioAdapterComponent.builder().root(root).maxFileNameLength(maxFileNameLength).build();
+		FuseNioAdapterComponent comp = DaggerFuseNioAdapterComponent.builder().root(root).maxFileNameLength(maxFileNameLength).toFuseEncoder(new DefaultEncoder()).build();
+		return comp.readWriteAdapter();
+	}
+
+	public static FuseNioAdapter createReadWriteAdapter(Path root, int maxFileNameLength, BufferEncoder toFuseEncoder) {
+		FuseNioAdapterComponent comp = DaggerFuseNioAdapterComponent.builder().root(root).maxFileNameLength(maxFileNameLength).toFuseEncoder(toFuseEncoder).build();
 		return comp.readWriteAdapter();
 	}
 }

--- a/src/main/java/org/cryptomator/frontend/fuse/AdapterFactory.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/AdapterFactory.java
@@ -13,11 +13,15 @@ public class AdapterFactory {
 	}
 
 	public static FuseNioAdapter createReadOnlyAdapter(Path root) {
-		return createReadOnlyAdapter(root, DEFAULT_NAME_MAX);
+		return createReadOnlyAdapter(root, DEFAULT_NAME_MAX, new DefaultEncoder());
 	}
 
-	public static FuseNioAdapter createReadOnlyAdapter(Path root, int maxFileNameLength) {
-		FuseNioAdapterComponent comp = DaggerFuseNioAdapterComponent.builder().root(root).maxFileNameLength(maxFileNameLength).build();
+	public static FuseNioAdapter createReadOnlyAdapter(Path root, int maxFileNameLength, BufferEncoder toFuseEncoder ) {
+		FuseNioAdapterComponent comp = DaggerFuseNioAdapterComponent.builder()
+				.root(root)
+				.maxFileNameLength(maxFileNameLength)
+				.toFuseEncoder(toFuseEncoder)
+				.build();
 		return comp.readOnlyAdapter();
 	}
 

--- a/src/main/java/org/cryptomator/frontend/fuse/FuseNioAdapterComponent.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/FuseNioAdapterComponent.java
@@ -2,6 +2,7 @@ package org.cryptomator.frontend.fuse;
 
 import dagger.BindsInstance;
 import dagger.Component;
+import org.cryptomator.frontend.fuse.encoding.BufferEncoder;
 
 import javax.inject.Named;
 import java.nio.file.Path;
@@ -22,6 +23,9 @@ public interface FuseNioAdapterComponent {
 
 		@BindsInstance
 		Builder maxFileNameLength(@Named("maxFileNameLength") int maxFileNameLength);
+
+		@BindsInstance
+		Builder toFuseEncoder(@Named("toFuseEncoder") BufferEncoder toFuseEncoder);
 
 		FuseNioAdapterComponent build();
 	}

--- a/src/main/java/org/cryptomator/frontend/fuse/FuseNioAdapterModule.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/FuseNioAdapterModule.java
@@ -10,6 +10,7 @@ import javax.inject.Named;
 
 import dagger.Module;
 import dagger.Provides;
+import org.cryptomator.frontend.fuse.encoding.BufferEncoder;
 
 @Module
 class FuseNioAdapterModule {
@@ -22,6 +23,12 @@ class FuseNioAdapterModule {
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		}
+	}
+
+	@Provides
+	@PerAdapter
+	protected BufferEncoder provideToFuseEncoder(@Named("toFuseEncoder") BufferEncoder enc){
+		return enc;
 	}
 
 }

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Iterables;
 import jnr.ffi.Pointer;
 import jnr.ffi.types.off_t;
 import jnr.ffi.types.size_t;
+import org.cryptomator.frontend.fuse.encoding.BufferEncoder;
 import org.cryptomator.frontend.fuse.locks.AlreadyLockedException;
 import org.cryptomator.frontend.fuse.locks.DataLock;
 import org.cryptomator.frontend.fuse.locks.LockManager;
@@ -53,6 +54,7 @@ public class ReadOnlyAdapter extends FuseStubFS implements FuseNioAdapter {
 	private final int maxFileNameLength;
 	protected final FileStore fileStore;
 	protected final LockManager lockManager;
+	protected final BufferEncoder toFuseEncoder;
 	private final ReadOnlyDirectoryHandler dirHandler;
 	private final ReadOnlyFileHandler fileHandler;
 	private final ReadOnlyLinkHandler linkHandler;
@@ -60,7 +62,7 @@ public class ReadOnlyAdapter extends FuseStubFS implements FuseNioAdapter {
 	private final BooleanSupplier hasOpenFiles;
 
 	@Inject
-	public ReadOnlyAdapter(@Named("root") Path root, @Named("maxFileNameLength") int maxFileNameLength, FileStore fileStore, LockManager lockManager, ReadOnlyDirectoryHandler dirHandler, ReadOnlyFileHandler fileHandler, ReadOnlyLinkHandler linkHandler, FileAttributesUtil attrUtil, OpenFileFactory fileFactory) {
+	public ReadOnlyAdapter(@Named("root") Path root, @Named("maxFileNameLength") int maxFileNameLength, @Named("toFuseEncoder") BufferEncoder toFuseEncoder, FileStore fileStore, LockManager lockManager, ReadOnlyDirectoryHandler dirHandler, ReadOnlyFileHandler fileHandler, ReadOnlyLinkHandler linkHandler, FileAttributesUtil attrUtil, OpenFileFactory fileFactory) {
 		this.root = root;
 		this.maxFileNameLength = maxFileNameLength;
 		this.fileStore = fileStore;
@@ -70,6 +72,7 @@ public class ReadOnlyAdapter extends FuseStubFS implements FuseNioAdapter {
 		this.linkHandler = linkHandler;
 		this.attrUtil = attrUtil;
 		this.hasOpenFiles = () -> fileFactory.getOpenFileCount() != 0;
+		this.toFuseEncoder = toFuseEncoder;
 	}
 
 	protected Path resolvePath(String absolutePath) {

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFileAttributes;
+import java.text.Normalizer;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
@@ -44,6 +45,8 @@ import java.util.function.BooleanSupplier;
 
 /**
  * Read-Only FUSE-NIO-Adapter based on Sergey Tselovalnikov's <a href="https://github.com/SerCeMan/jnr-fuse/blob/0.5.1/src/main/java/ru/serce/jnrfuse/examples/HelloFuse.java">HelloFuse</a>
+ * <p>
+ * Any (string) path from a fuse callback is normalized into its NFC representation before it is transformed into a {@link java.nio.file.Path}.
  */
 @PerAdapter
 public class ReadOnlyAdapter extends FuseStubFS implements FuseNioAdapter {
@@ -76,7 +79,8 @@ public class ReadOnlyAdapter extends FuseStubFS implements FuseNioAdapter {
 	}
 
 	protected Path resolvePath(String absolutePath) {
-		String relativePath = CharMatcher.is('/').trimLeadingFrom(absolutePath);
+		var normalizedAbsolutePath = Normalizer.normalize(absolutePath, Normalizer.Form.NFC);
+		String relativePath = CharMatcher.is('/').trimLeadingFrom(normalizedAbsolutePath);
 		return root.resolve(relativePath);
 	}
 

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadWriteAdapter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadWriteAdapter.java
@@ -7,6 +7,7 @@ import jnr.ffi.types.mode_t;
 import jnr.ffi.types.off_t;
 import jnr.ffi.types.size_t;
 import jnr.ffi.types.uid_t;
+import org.cryptomator.frontend.fuse.encoding.BufferEncoder;
 import org.cryptomator.frontend.fuse.locks.DataLock;
 import org.cryptomator.frontend.fuse.locks.LockManager;
 import org.cryptomator.frontend.fuse.locks.PathLock;
@@ -51,8 +52,8 @@ public class ReadWriteAdapter extends ReadOnlyAdapter {
 	private final BitMaskEnumUtil bitMaskUtil;
 
 	@Inject
-	public ReadWriteAdapter(@Named("root") Path root, @Named("maxFileNameLength") int maxFileNameLength, FileStore fileStore, LockManager lockManager, ReadWriteDirectoryHandler dirHandler, ReadWriteFileHandler fileHandler, ReadOnlyLinkHandler linkHandler, FileAttributesUtil attrUtil, BitMaskEnumUtil bitMaskUtil, OpenFileFactory fileFactory) {
-		super(root, maxFileNameLength, fileStore, lockManager, dirHandler, fileHandler, linkHandler, attrUtil, fileFactory);
+	public ReadWriteAdapter(@Named("root") Path root, @Named("maxFileNameLength") int maxFileNameLength, @Named("toFuseEncoder") BufferEncoder toFuseEncoder, FileStore fileStore, LockManager lockManager, ReadWriteDirectoryHandler dirHandler, ReadWriteFileHandler fileHandler, ReadOnlyLinkHandler linkHandler, FileAttributesUtil attrUtil, BitMaskEnumUtil bitMaskUtil, OpenFileFactory fileFactory) {
+		super(root, maxFileNameLength, toFuseEncoder, fileStore, lockManager, dirHandler, fileHandler, linkHandler, attrUtil, fileFactory);
 		this.fileHandler = fileHandler;
 		this.attrUtil = attrUtil;
 		this.bitMaskUtil = bitMaskUtil;

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadWriteDirectoryHandler.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadWriteDirectoryHandler.java
@@ -1,5 +1,6 @@
 package org.cryptomator.frontend.fuse;
 
+import org.cryptomator.frontend.fuse.encoding.BufferEncoder;
 import ru.serce.jnrfuse.struct.FileStat;
 
 import javax.inject.Inject;
@@ -11,8 +12,8 @@ import java.nio.file.attribute.PosixFileAttributes;
 public class ReadWriteDirectoryHandler extends ReadOnlyDirectoryHandler {
 
 	@Inject
-	public ReadWriteDirectoryHandler(FileAttributesUtil attrUtil) {
-		super(attrUtil);
+	public ReadWriteDirectoryHandler(FileAttributesUtil attrUtil, BufferEncoder toFuseEncoder) {
+		super(attrUtil, toFuseEncoder);
 	}
 
 	@Override

--- a/src/main/java/org/cryptomator/frontend/fuse/encoding/BufferEncoder.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/encoding/BufferEncoder.java
@@ -2,7 +2,7 @@ package org.cryptomator.frontend.fuse.encoding;
 
 import java.nio.ByteBuffer;
 
-public interface FuseEncoder {
+public interface BufferEncoder {
 
 	String getEncodingDescription();
 

--- a/src/main/java/org/cryptomator/frontend/fuse/encoding/DefaultEncoder.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/encoding/DefaultEncoder.java
@@ -2,7 +2,7 @@ package org.cryptomator.frontend.fuse.encoding;
 
 import java.nio.ByteBuffer;
 
-public class DefaultEncoder implements FuseEncoder {
+public class DefaultEncoder implements BufferEncoder {
 
 	@Override
 	public String getEncodingDescription() {

--- a/src/main/java/org/cryptomator/frontend/fuse/encoding/DefaultEncoder.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/encoding/DefaultEncoder.java
@@ -1,18 +1,12 @@
 package org.cryptomator.frontend.fuse.encoding;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 
 public class DefaultEncoder implements FuseEncoder {
 
 	@Override
 	public String getEncodingDescription() {
 		return "Default Charset encoding";
-	}
-
-	@Override
-	public Charset getTargetCharset() {
-		return Charset.defaultCharset();
 	}
 
 	@Override

--- a/src/main/java/org/cryptomator/frontend/fuse/encoding/DefaultEncoder.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/encoding/DefaultEncoder.java
@@ -1,0 +1,22 @@
+package org.cryptomator.frontend.fuse.encoding;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+
+public class DefaultEncoder implements FuseEncoder {
+
+	@Override
+	public String getEncodingDescription() {
+		return "Default Charset encoding";
+	}
+
+	@Override
+	public Charset getTargetCharset() {
+		return Charset.defaultCharset();
+	}
+
+	@Override
+	public ByteBuffer encode(CharSequence s) {
+		return ByteBuffer.wrap(s.toString().getBytes());
+	}
+}

--- a/src/main/java/org/cryptomator/frontend/fuse/encoding/FuseEncoder.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/encoding/FuseEncoder.java
@@ -1,13 +1,10 @@
 package org.cryptomator.frontend.fuse.encoding;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 
 public interface FuseEncoder {
 
 	String getEncodingDescription();
-
-	Charset getTargetCharset();
 
 	ByteBuffer encode(CharSequence s);
 

--- a/src/main/java/org/cryptomator/frontend/fuse/encoding/FuseEncoder.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/encoding/FuseEncoder.java
@@ -1,0 +1,14 @@
+package org.cryptomator.frontend.fuse.encoding;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+
+public interface FuseEncoder {
+
+	String getEncodingDescription();
+
+	Charset getTargetCharset();
+
+	ByteBuffer encode(CharSequence s);
+
+}

--- a/src/main/java/org/cryptomator/frontend/fuse/encoding/UTF8NFCEncoder.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/encoding/UTF8NFCEncoder.java
@@ -1,0 +1,27 @@
+package org.cryptomator.frontend.fuse.encoding;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.text.Normalizer;
+
+public class UTF8NFCEncoder implements FuseEncoder {
+
+	private final static Charset UTF8 = StandardCharsets.UTF_8;
+
+	@Override
+	public String getEncodingDescription() {
+		return "UTF-8 in NFC";
+	}
+
+	@Override
+	public Charset getTargetCharset() {
+		return UTF8;
+	}
+
+	@Override
+	public ByteBuffer encode(CharSequence s) {
+		String nfcS = Normalizer.normalize(s, Normalizer.Form.NFC);
+		return UTF8.encode(nfcS);
+	}
+}

--- a/src/main/java/org/cryptomator/frontend/fuse/encoding/UTF8NFCEncoder.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/encoding/UTF8NFCEncoder.java
@@ -15,11 +15,6 @@ public class UTF8NFCEncoder implements FuseEncoder {
 	}
 
 	@Override
-	public Charset getTargetCharset() {
-		return UTF8;
-	}
-
-	@Override
 	public ByteBuffer encode(CharSequence s) {
 		String nfcS = Normalizer.normalize(s, Normalizer.Form.NFC);
 		return UTF8.encode(nfcS);

--- a/src/main/java/org/cryptomator/frontend/fuse/encoding/UTF8NFCEncoder.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/encoding/UTF8NFCEncoder.java
@@ -5,7 +5,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 
-public class UTF8NFCEncoder implements FuseEncoder {
+public class UTF8NFCEncoder implements BufferEncoder {
 
 	private final static Charset UTF8 = StandardCharsets.UTF_8;
 

--- a/src/main/java/org/cryptomator/frontend/fuse/encoding/UTF8NFDEncoder.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/encoding/UTF8NFDEncoder.java
@@ -6,7 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 
 //TODO: for MacOS standard NFD is not enough
-public class UTF8NFDEncoder implements FuseEncoder {
+public class UTF8NFDEncoder implements BufferEncoder {
 
 	private final static Charset UTF8 = StandardCharsets.UTF_8;
 

--- a/src/main/java/org/cryptomator/frontend/fuse/encoding/UTF8NFDEncoder.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/encoding/UTF8NFDEncoder.java
@@ -1,0 +1,28 @@
+package org.cryptomator.frontend.fuse.encoding;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.text.Normalizer;
+
+//TODO: for MacOS standard NFD is not enough
+public class UTF8NFDEncoder implements FuseEncoder {
+
+	private final static Charset UTF8 = StandardCharsets.UTF_8;
+
+	@Override
+	public String getEncodingDescription() {
+		return "UTF-8 in NFD";
+	}
+
+	@Override
+	public Charset getTargetCharset() {
+		return UTF8;
+	}
+
+	@Override
+	public ByteBuffer encode(CharSequence s) {
+		String normalizedS = Normalizer.normalize(s, Normalizer.Form.NFD);
+		return UTF8.encode(normalizedS);
+	}
+}

--- a/src/main/java/org/cryptomator/frontend/fuse/encoding/UTF8NFDEncoder.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/encoding/UTF8NFDEncoder.java
@@ -16,11 +16,6 @@ public class UTF8NFDEncoder implements FuseEncoder {
 	}
 
 	@Override
-	public Charset getTargetCharset() {
-		return UTF8;
-	}
-
-	@Override
 	public ByteBuffer encode(CharSequence s) {
 		String normalizedS = Normalizer.normalize(s, Normalizer.Form.NFD);
 		return UTF8.encode(normalizedS);

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/MacMounter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/MacMounter.java
@@ -3,6 +3,7 @@ package org.cryptomator.frontend.fuse.mount;
 import com.google.common.base.Preconditions;
 import org.cryptomator.frontend.fuse.AdapterFactory;
 import org.cryptomator.frontend.fuse.FuseNioAdapter;
+import org.cryptomator.frontend.fuse.encoding.UTF8NFDEncoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -41,7 +42,7 @@ class MacMounter implements Mounter {
 
 	@Override
 	public synchronized Mount mount(Path directory, boolean blocking, boolean debug, EnvironmentVariables envVars) throws CommandFailedException {
-		FuseNioAdapter fuseAdapter = AdapterFactory.createReadWriteAdapter(directory);
+		FuseNioAdapter fuseAdapter = AdapterFactory.createReadWriteAdapter(directory,254,new UTF8NFDEncoder());
 		try {
 			fuseAdapter.mount(envVars.getMountPoint(), blocking, debug, envVars.getFuseFlags());
 		} catch (RuntimeException e) {
@@ -60,7 +61,6 @@ class MacMounter implements Mounter {
 					"-oatomic_o_trunc",
 					"-oauto_xattr",
 					"-oauto_cache",
-					"-omodules=iconv,from_code=UTF-8,to_code=UTF-8-MAC", // show files names in Unicode NFD encoding
 					"-onoappledouble", // vastly impacts performance for some reason...
 					"-odefault_permissions" // let the kernel assume permissions based on file attributes etc
 			};


### PR DESCRIPTION
Closes #56.

## Implemented Solution
Replacing the usage of the iconv-module by encoding/decoding strings in the FuseNioAdapter itself.

## Implementation Details
A new package is added with the Interface `BufferEncoder`. It requires the method `ByteBuffer encode(CharSequence s)` to be implemented. Two example and one default implementations are given.

This interface is integrated into the project by adding it as a instance variable of the `ReadOnlyAdapter`, which can be set by calling the correct factory method of the `AdapterFactory`. Any write of a String into a native FUSE buffer is replaced by writing a byte buffer with the desired encoding. The FUSE read and write methods are not touched.

Additionally, each string constructed from a FUSE callback is normalized with NFC. This behaviour is also documented.

## Remarks
If the "normal" UTF-8-NFD encoding is sufficient needs to be tested, there is the possibility that our own NFD encoding scheme needs to be implemented. (see https://developer.apple.com/library/archive/qa/qa1173/_index.html) A suitable testcharacter would be 切 (U+FA00).