### PR TITLE
Feature/#56 transcoder

### DIFF
--- a/src/main/java/org/cryptomator/frontend/fuse/AdapterFactory.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/AdapterFactory.java
@@ -10,11 +10,15 @@ public class AdapterFactory {
 	}
 
 	public static FuseNioAdapter createReadOnlyAdapter(Path root) {
-		return createReadOnlyAdapter(root, DEFAULT_NAME_MAX);
+		return createReadOnlyAdapter(root, DEFAULT_NAME_MAX, FileNameTranscoder.transcoder() );
 	}
 
-	public static FuseNioAdapter createReadOnlyAdapter(Path root, int maxFileNameLength) {
-		FuseNioAdapterComponent comp = DaggerFuseNioAdapterComponent.builder().root(root).maxFileNameLength(maxFileNameLength).build();
+	public static FuseNioAdapter createReadOnlyAdapter(Path root, int maxFileNameLength, FileNameTranscoder fileNameTranscoder) {
+		FuseNioAdapterComponent comp = DaggerFuseNioAdapterComponent.builder()
+				.root(root)
+				.maxFileNameLength(maxFileNameLength)
+				.fileNameTranscoder(fileNameTranscoder)
+				.build();
 		return comp.readOnlyAdapter();
 	}
 
@@ -23,7 +27,12 @@ public class AdapterFactory {
 	}
 
 	public static FuseNioAdapter createReadWriteAdapter(Path root, int maxFileNameLength) {
-		FuseNioAdapterComponent comp = DaggerFuseNioAdapterComponent.builder().root(root).maxFileNameLength(maxFileNameLength).build();
+		FuseNioAdapterComponent comp = DaggerFuseNioAdapterComponent.builder().root(root).maxFileNameLength(maxFileNameLength).fileNameTranscoder(FileNameTranscoder.transcoder()).build();
+		return comp.readWriteAdapter();
+	}
+
+	public static FuseNioAdapter createReadWriteAdapter(Path root, int maxFileNameLength, FileNameTranscoder fileNameTranscoder) {
+		FuseNioAdapterComponent comp = DaggerFuseNioAdapterComponent.builder().root(root).maxFileNameLength(maxFileNameLength).fileNameTranscoder(fileNameTranscoder).build();
 		return comp.readWriteAdapter();
 	}
 }

--- a/src/main/java/org/cryptomator/frontend/fuse/AdapterFactory.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/AdapterFactory.java
@@ -9,6 +9,13 @@ public class AdapterFactory {
 	private AdapterFactory() {
 	}
 
+	/**
+	 * Creates a read-only fuse-nio filesystem with a maximum file name length of {@value DEFAULT_NAME_MAX} and an assumed filename encoding of UTF-8 NFC for FUSE and the NIO filesystem.
+	 * @param root the root path of the NIO filesystem.
+	 * @return an adapter mapping FUSE callbacks to the nio interface
+	 * @see ReadOnlyAdapter
+	 * @see FileNameTranscoder
+	 */
 	public static FuseNioAdapter createReadOnlyAdapter(Path root) {
 		return createReadOnlyAdapter(root, DEFAULT_NAME_MAX, FileNameTranscoder.transcoder() );
 	}
@@ -22,10 +29,24 @@ public class AdapterFactory {
 		return comp.readOnlyAdapter();
 	}
 
+	/**
+	 * Creates a fuse-nio-filesystem with a maximum file name length of {@value DEFAULT_NAME_MAX} and an assumed filename encoding of UTF-8 NFC for FUSE and the NIO filesystem.
+	 * @param root the root path of the NIO filesystem.
+	 * @return an adapter mapping FUSE callbacks to the nio interface
+	 * @see ReadWriteAdapter
+	 * @see FileNameTranscoder
+	 */
 	public static FuseNioAdapter createReadWriteAdapter(Path root) {
 		return createReadWriteAdapter(root, DEFAULT_NAME_MAX);
 	}
 
+	/**
+	 * Creates a fuse-nio-filesystem with an assumed filename encoding of UTF-8 NFC for FUSE and the NIO filesystem.
+	 * @param root the root path of the NIO filesystem.
+	 * @return an adapter mapping FUSE callbacks to the nio interface
+	 * @see ReadWriteAdapter
+	 * @see FileNameTranscoder
+	 */
 	public static FuseNioAdapter createReadWriteAdapter(Path root, int maxFileNameLength) {
 		FuseNioAdapterComponent comp = DaggerFuseNioAdapterComponent.builder().root(root).maxFileNameLength(maxFileNameLength).fileNameTranscoder(FileNameTranscoder.transcoder()).build();
 		return comp.readWriteAdapter();

--- a/src/main/java/org/cryptomator/frontend/fuse/AdapterFactory.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/AdapterFactory.java
@@ -4,20 +4,23 @@ import java.nio.file.Path;
 
 public class AdapterFactory {
 
-	private static final int DEFAULT_NAME_MAX = 254; // 255 is preferred, but nautilus checks for this value + 1
+	/**
+	 * The default value for the maximum supported filename length.
+	 */
+	public static final int DEFAULT_MAX_FILENAMELENGTH = 254; // 255 is preferred, but nautilus checks for this value + 1
 
 	private AdapterFactory() {
 	}
 
 	/**
-	 * Creates a read-only fuse-nio filesystem with a maximum file name length of {@value DEFAULT_NAME_MAX} and an assumed filename encoding of UTF-8 NFC for FUSE and the NIO filesystem.
+	 * Creates a read-only fuse-nio filesystem with a maximum file name length of {@value DEFAULT_MAX_FILENAMELENGTH} and an assumed filename encoding of UTF-8 NFC for FUSE and the NIO filesystem.
 	 * @param root the root path of the NIO filesystem.
 	 * @return an adapter mapping FUSE callbacks to the nio interface
 	 * @see ReadOnlyAdapter
 	 * @see FileNameTranscoder
 	 */
 	public static FuseNioAdapter createReadOnlyAdapter(Path root) {
-		return createReadOnlyAdapter(root, DEFAULT_NAME_MAX, FileNameTranscoder.transcoder() );
+		return createReadOnlyAdapter(root, DEFAULT_MAX_FILENAMELENGTH, FileNameTranscoder.transcoder() );
 	}
 
 	public static FuseNioAdapter createReadOnlyAdapter(Path root, int maxFileNameLength, FileNameTranscoder fileNameTranscoder) {
@@ -30,14 +33,14 @@ public class AdapterFactory {
 	}
 
 	/**
-	 * Creates a fuse-nio-filesystem with a maximum file name length of {@value DEFAULT_NAME_MAX} and an assumed filename encoding of UTF-8 NFC for FUSE and the NIO filesystem.
+	 * Creates a fuse-nio-filesystem with a maximum file name length of {@value DEFAULT_MAX_FILENAMELENGTH} and an assumed filename encoding of UTF-8 NFC for FUSE and the NIO filesystem.
 	 * @param root the root path of the NIO filesystem.
 	 * @return an adapter mapping FUSE callbacks to the nio interface
 	 * @see ReadWriteAdapter
 	 * @see FileNameTranscoder
 	 */
 	public static FuseNioAdapter createReadWriteAdapter(Path root) {
-		return createReadWriteAdapter(root, DEFAULT_NAME_MAX);
+		return createReadWriteAdapter(root, DEFAULT_MAX_FILENAMELENGTH);
 	}
 
 	/**
@@ -48,8 +51,7 @@ public class AdapterFactory {
 	 * @see FileNameTranscoder
 	 */
 	public static FuseNioAdapter createReadWriteAdapter(Path root, int maxFileNameLength) {
-		FuseNioAdapterComponent comp = DaggerFuseNioAdapterComponent.builder().root(root).maxFileNameLength(maxFileNameLength).fileNameTranscoder(FileNameTranscoder.transcoder()).build();
-		return comp.readWriteAdapter();
+		return createReadWriteAdapter(root,maxFileNameLength,FileNameTranscoder.transcoder());
 	}
 
 	public static FuseNioAdapter createReadWriteAdapter(Path root, int maxFileNameLength, FileNameTranscoder fileNameTranscoder) {

--- a/src/main/java/org/cryptomator/frontend/fuse/FileNameTranscoder.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/FileNameTranscoder.java
@@ -47,10 +47,20 @@ public class FileNameTranscoder {
 		return transcode(fuseFileName, fuseCharset, nioCharset, fuseNormalization, nioNormalization);
 	}
 
+	/**
+	 * Interprets the given string as FUSE character set encoded and returns the original byte sequence.
+	 * @param fuseFileName string from the fuse layer
+	 * @return A byte sequence with the original encoding of the input
+	 */
 	public ByteBuffer interpretAsFuseString(String fuseFileName) {
 		return fuseCharset.encode(fuseFileName);
 	}
 
+	/**
+	 * Interprets the given string as NIO character set encoded and returns the original byte sequence.
+	 * @param nioFileName string from the nio layer
+	 * @return A byte sequence with the original encoding of the input
+	 */
 	public ByteBuffer interpretAsNioString(String nioFileName) {
 		return nioCharset.encode(nioFileName);
 	}

--- a/src/main/java/org/cryptomator/frontend/fuse/FileNameTranscoder.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/FileNameTranscoder.java
@@ -70,8 +70,8 @@ public class FileNameTranscoder {
 
 	/* Builder */
 	public static FileNameTranscoder transcoder(Charset fuseCharset, Charset nioCharset, Normalizer.Form fuseNormalization, Normalizer.Form nioNormalization) {
-		if (fuseNormalization != null && UTF_MATCH.matcher(fuseCharset.displayName()).matches() //
-				|| nioNormalization != null && UTF_MATCH.matcher(nioCharset.displayName()).matches()) {
+		if ((fuseNormalization != null && !UTF_MATCH.matcher(fuseCharset.displayName()).matches()) //
+				|| (nioNormalization != null && !UTF_MATCH.matcher(nioCharset.displayName()).matches())) {
 			throw new IllegalArgumentException("Normalization only applicable to utf encodings");
 		}
 		return new FileNameTranscoder(fuseCharset, nioCharset, fuseNormalization, nioNormalization);

--- a/src/main/java/org/cryptomator/frontend/fuse/FileNameTranscoder.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/FileNameTranscoder.java
@@ -21,16 +21,16 @@ public class FileNameTranscoder {
 	private final Charset nioCharset;
 	private final Normalizer.Form fuseNormalization;
 	private final Normalizer.Form nioNormalization;
-	private final boolean fuseCharsetIsUTF;
-	private final boolean nioCharsetIsUTF;
+	private final boolean fuseCharsetIsUnicode;
+	private final boolean nioCharsetIsUnicode;
 
 	FileNameTranscoder(Charset fuseCharset, Charset nioCharset, Normalizer.Form fuseNormalization, Normalizer.Form nioNormalization) {
 		this.fuseCharset = Preconditions.checkNotNull(fuseCharset);
 		this.nioCharset = Preconditions.checkNotNull(nioCharset);
 		this.fuseNormalization = Preconditions.checkNotNull(fuseNormalization);
 		this.nioNormalization = Preconditions.checkNotNull(nioNormalization);
-		this.fuseCharsetIsUTF = fuseCharset.displayName().toUpperCase().startsWith("UTF");
-		this.nioCharsetIsUTF = nioCharset.displayName().toUpperCase().startsWith("UTF");
+		this.fuseCharsetIsUnicode = fuseCharset.name().startsWith("UTF");
+		this.nioCharsetIsUnicode = nioCharset.name().startsWith("UTF");
 	}
 
 	/**
@@ -40,7 +40,7 @@ public class FileNameTranscoder {
 	 * @return The file name encoded with the charset used by FUSE
 	 */
 	public String nioToFuse(String nioFileName) {
-		return transcode(nioFileName, nioCharset, fuseCharset, fuseNormalization, fuseCharsetIsUTF);
+		return transcode(nioFileName, nioCharset, fuseCharset, nioNormalization, fuseNormalization, fuseCharsetIsUnicode);
 	}
 
 	/**
@@ -50,7 +50,7 @@ public class FileNameTranscoder {
 	 * @return The file name encoded with the charset used by NIO
 	 */
 	public String fuseToNio(String fuseFileName) {
-		return transcode(fuseFileName, fuseCharset, nioCharset, nioNormalization, nioCharsetIsUTF);
+		return transcode(fuseFileName, fuseCharset, nioCharset, fuseNormalization, nioNormalization, nioCharsetIsUnicode);
 	}
 
 	/**
@@ -73,12 +73,12 @@ public class FileNameTranscoder {
 		return nioCharset.encode(nioFileName);
 	}
 
-	private String transcode(String original, Charset srcCharset, Charset dstCharset, Normalizer.Form dstNormalization, boolean applyNormalization) {
+	private String transcode(String original, Charset srcCharset, Charset dstCharset, Normalizer.Form srcNormalization, Normalizer.Form dstNormalization, boolean applyNormalization) {
 		String result = original;
 		if (!srcCharset.equals(dstCharset)) {
 			result = dstCharset.decode(srcCharset.encode(result)).toString();
 		}
-		if (applyNormalization) {
+		if (applyNormalization && srcNormalization != dstNormalization) {
 			result = Normalizer.normalize(result, dstNormalization);
 		}
 		return result;

--- a/src/main/java/org/cryptomator/frontend/fuse/FileNameTranscoder.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/FileNameTranscoder.java
@@ -1,0 +1,87 @@
+package org.cryptomator.frontend.fuse;
+
+import com.google.common.base.Preconditions;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.text.Normalizer;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+public class FileNameTranscoder {
+
+	private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+	private static final Normalizer.Form DEFAULT_NORMALIZATION = Normalizer.Form.NFC;
+	private static final Pattern UTF_MATCH = Pattern.compile("(utf|UTF)-?(8|((16|32)(BE|LE|be|le)?))");
+
+	private final Charset fuseCharset;
+	private final Charset nioCharset;
+	private final Optional<Normalizer.Form> fuseNormalization;
+	private final Optional<Normalizer.Form> nioNormalization;
+
+	private FileNameTranscoder(Charset fuseCharset, Charset nioCharset, Normalizer.Form fuseNormalization, Normalizer.Form nioNormalization) {
+		this.fuseCharset = Preconditions.checkNotNull(fuseCharset);
+		this.nioCharset = Preconditions.checkNotNull(nioCharset);
+		this.fuseNormalization = Optional.ofNullable(fuseNormalization);
+		this.nioNormalization = Optional.ofNullable(nioNormalization);
+	}
+
+	/**
+	 * Transcodes the given NIO file name to FUSE representation.
+	 *
+	 * @param nioFileName A file name encoded with the charset used in NIO
+	 * @return The file name encoded with the charset used by FUSE
+	 */
+	public String nioToFuse(String nioFileName) {
+		return transcode(nioFileName, nioCharset, fuseCharset, nioNormalization, fuseNormalization);
+	}
+
+	/**
+	 * Transcodes the given FUSE file name to NIO representation.
+	 *
+	 * @param fuseFileName A file name encoded with the charset used in FUSE
+	 * @return The file name encoded with the charset used by NIO
+	 */
+	public String fuseToNio(String fuseFileName) {
+		return transcode(fuseFileName, fuseCharset, nioCharset, fuseNormalization, nioNormalization);
+	}
+
+	public ByteBuffer interpretAsFuseString(String fuseFileName) {
+		return fuseCharset.encode(fuseFileName);
+	}
+
+	public ByteBuffer interpretAsNioString(String nioFileName) {
+		return nioCharset.encode(nioFileName);
+	}
+
+	private String transcode(String original, Charset srcCharset, Charset dstCharset, Optional<Normalizer.Form> srcNormalization, Optional<Normalizer.Form> dstNormalization) {
+		String result = original;
+		if (!srcCharset.equals(dstCharset)) {
+			result = dstCharset.decode(srcCharset.encode(result)).toString();
+		}
+		if (dstNormalization.isPresent()) {
+			if ((srcNormalization.isPresent() && !srcNormalization.get().equals(dstNormalization.get())) || srcNormalization.isEmpty()) {
+				Normalizer.normalize(result, dstNormalization.get());
+			}
+		}
+		return result;
+	}
+
+	/* Builder */
+	public static FileNameTranscoder transcoder(Charset fuseCharset, Charset nioCharset, Normalizer.Form fuseNormalization, Normalizer.Form nioNormalization) {
+		if (fuseNormalization != null && UTF_MATCH.matcher(fuseCharset.displayName()).matches() //
+				|| nioNormalization != null && UTF_MATCH.matcher(nioCharset.displayName()).matches()) {
+			throw new IllegalArgumentException("Normalization only applicable to utf encodings");
+		}
+		return new FileNameTranscoder(fuseCharset, nioCharset, fuseNormalization, nioNormalization);
+	}
+
+	public static FileNameTranscoder transcoder(Charset fuseCharset, Charset nioCharset) {
+		return new FileNameTranscoder(fuseCharset, nioCharset, null, null);
+	}
+	//TODO: maybe let the FUSE charset be Charset.defaultCharset() ?
+	public static FileNameTranscoder transcoder() {
+		return new FileNameTranscoder(DEFAULT_CHARSET, DEFAULT_CHARSET, DEFAULT_NORMALIZATION, DEFAULT_NORMALIZATION);
+	}
+}

--- a/src/main/java/org/cryptomator/frontend/fuse/FuseNioAdapterComponent.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/FuseNioAdapterComponent.java
@@ -23,6 +23,9 @@ public interface FuseNioAdapterComponent {
 		@BindsInstance
 		Builder maxFileNameLength(@Named("maxFileNameLength") int maxFileNameLength);
 
+		@BindsInstance
+		Builder fileNameTranscoder(FileNameTranscoder fileNameTranscoder);
+
 		FuseNioAdapterComponent build();
 	}
 

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
@@ -53,6 +53,7 @@ public class ReadOnlyAdapter extends FuseStubFS implements FuseNioAdapter {
 	private final int maxFileNameLength;
 	protected final FileStore fileStore;
 	protected final LockManager lockManager;
+	protected final FileNameTranscoder fileNameTranscoder;
 	private final ReadOnlyDirectoryHandler dirHandler;
 	private final ReadOnlyFileHandler fileHandler;
 	private final ReadOnlyLinkHandler linkHandler;
@@ -60,9 +61,10 @@ public class ReadOnlyAdapter extends FuseStubFS implements FuseNioAdapter {
 	private final BooleanSupplier hasOpenFiles;
 
 	@Inject
-	public ReadOnlyAdapter(@Named("root") Path root, @Named("maxFileNameLength") int maxFileNameLength, FileStore fileStore, LockManager lockManager, ReadOnlyDirectoryHandler dirHandler, ReadOnlyFileHandler fileHandler, ReadOnlyLinkHandler linkHandler, FileAttributesUtil attrUtil, OpenFileFactory fileFactory) {
+	public ReadOnlyAdapter(@Named("root") Path root, @Named("maxFileNameLength") int maxFileNameLength, FileNameTranscoder fileNameTranscoder, FileStore fileStore, LockManager lockManager, ReadOnlyDirectoryHandler dirHandler, ReadOnlyFileHandler fileHandler, ReadOnlyLinkHandler linkHandler, FileAttributesUtil attrUtil, OpenFileFactory fileFactory) {
 		this.root = root;
 		this.maxFileNameLength = maxFileNameLength;
+		this.fileNameTranscoder = fileNameTranscoder;
 		this.fileStore = fileStore;
 		this.lockManager = lockManager;
 		this.dirHandler = dirHandler;
@@ -73,7 +75,8 @@ public class ReadOnlyAdapter extends FuseStubFS implements FuseNioAdapter {
 	}
 
 	protected Path resolvePath(String absolutePath) {
-		String relativePath = CharMatcher.is('/').trimLeadingFrom(absolutePath);
+		var nioSuitablePath = fileNameTranscoder.fuseToNio(absolutePath);
+		String relativePath = CharMatcher.is('/').trimLeadingFrom(nioSuitablePath);
 		return root.resolve(relativePath);
 	}
 

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
@@ -103,8 +103,7 @@ public class ReadOnlyAdapter extends FuseStubFS implements FuseNioAdapter {
 	@Override
 	public int access(String path, int mask) {
 		try {
-			var nioSuitablePath = fileNameTranscoder.fuseToNio(path);
-			Path node = resolvePath(nioSuitablePath);
+			Path node = resolvePath(fileNameTranscoder.fuseToNio(path));
 			Set<AccessMode> accessModes = attrUtil.accessModeMaskToSet(mask);
 			return checkAccess(node, accessModes);
 		} catch (RuntimeException e) {
@@ -138,8 +137,7 @@ public class ReadOnlyAdapter extends FuseStubFS implements FuseNioAdapter {
 	public int readlink(String path, Pointer buf, long size) {
 		try (PathLock pathLock = lockManager.createPathLock(path).forReading();
 			 DataLock dataLock = pathLock.lockDataForReading()) {
-			var nioSuitablePath = fileNameTranscoder.fuseToNio(path);
-			Path node = resolvePath(nioSuitablePath);
+			Path node = resolvePath(fileNameTranscoder.fuseToNio(path));
 			return linkHandler.readlink(node, buf, size);
 		} catch (NotLinkException | NoSuchFileException e) {
 			LOG.trace("readlink {} failed, node not found or not a symlink", path);
@@ -154,8 +152,7 @@ public class ReadOnlyAdapter extends FuseStubFS implements FuseNioAdapter {
 	public int getattr(String path, FileStat stat) {
 		try (PathLock pathLock = lockManager.createPathLock(path).forReading();
 			 DataLock dataLock = pathLock.lockDataForReading()) {
-			var nioSuitablePath = fileNameTranscoder.fuseToNio(path);
-			Path node = resolvePath(nioSuitablePath);
+			Path node = resolvePath(fileNameTranscoder.fuseToNio(path));
 			BasicFileAttributes attrs;
 			if (fileStore.supportsFileAttributeView(PosixFileAttributeView.class)) {
 				attrs = Files.readAttributes(node, PosixFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
@@ -188,8 +185,7 @@ public class ReadOnlyAdapter extends FuseStubFS implements FuseNioAdapter {
 	public int readdir(String path, Pointer buf, FuseFillDir filler, @off_t long offset, FuseFileInfo fi) {
 		try (PathLock pathLock = lockManager.createPathLock(path).forReading();
 			 DataLock dataLock = pathLock.lockDataForReading()) {
-			var nioSuitablePath = fileNameTranscoder.fuseToNio(path);
-			Path node = resolvePath(nioSuitablePath);
+			Path node = resolvePath(fileNameTranscoder.fuseToNio(path));
 			LOG.trace("readdir {}", path);
 			return dirHandler.readdir(node, buf, filler, offset, fi);
 		} catch (NotDirectoryException e) {
@@ -205,8 +201,7 @@ public class ReadOnlyAdapter extends FuseStubFS implements FuseNioAdapter {
 	public int open(String path, FuseFileInfo fi) {
 		try (PathLock pathLock = lockManager.createPathLock(path).forReading();
 			 DataLock dataLock = pathLock.lockDataForReading()) {
-			var nioSuitablePath = fileNameTranscoder.fuseToNio(path);
-			Path node = resolvePath(nioSuitablePath);
+			Path node = resolvePath(fileNameTranscoder.fuseToNio(path));
 			LOG.trace("open {} ({})", path, fi.fh.get());
 			fileHandler.open(node, fi);
 			return 0;

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyDirectoryHandler.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyDirectoryHandler.java
@@ -25,10 +25,12 @@ public class ReadOnlyDirectoryHandler {
 	private static final Path SAME_DIR = Paths.get(".");
 	private static final Path PARENT_DIR = Paths.get("..");
 	protected final FileAttributesUtil attrUtil;
+	private final FileNameTranscoder fileNameTranscoder;
 
 	@Inject
-	public ReadOnlyDirectoryHandler(FileAttributesUtil attrUtil) {
+	public ReadOnlyDirectoryHandler(FileAttributesUtil attrUtil, FileNameTranscoder fileNameTranscoder) {
 		this.attrUtil = attrUtil;
+		this.fileNameTranscoder = fileNameTranscoder;
 	}
 
 	public int getattr(Path path, BasicFileAttributes attrs, FileStat stat) {
@@ -75,7 +77,7 @@ public class ReadOnlyDirectoryHandler {
 			Iterator<Path> iter = Iterators.concat(sameAndParent, ds.iterator());
 			while (iter.hasNext()) {
 				String fileName = iter.next().getFileName().toString();
-				if (filler.apply(buf, fileName, null, 0) != 0) {
+				if (filler.apply(buf, fileNameTranscoder.nioToFuse(fileName), null, 0) != 0) {
 					return -ErrorCodes.ENOMEM();
 				}
 			}

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyLinkHandler.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyLinkHandler.java
@@ -51,9 +51,10 @@ class ReadOnlyLinkHandler {
 	public int readlink(Path path, Pointer buf, long size) throws IOException {
 		Path target = Files.readSymbolicLink(path);
 		ByteBuffer fuseEncodedTarget = fileNameTranscoder.interpretAsFuseString(fileNameTranscoder.nioToFuse(target.toString()));
-		int maxSize = size == 0 ? 0 : (int) size - 1;
-		buf.put(0, fuseEncodedTarget.array(),0, fuseEncodedTarget.capacity());
-		buf.putByte(maxSize, (byte) 0x00);
+		int len = (int) Math.min(fuseEncodedTarget.remaining(), size - 1);
+		assert len < size;
+		buf.put(0, fuseEncodedTarget.array(), 0, len);
+		buf.putByte(len, (byte) 0x00); // add null terminator
 		return 0;
 	}
 

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadWriteAdapter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadWriteAdapter.java
@@ -51,8 +51,8 @@ public class ReadWriteAdapter extends ReadOnlyAdapter {
 	private final BitMaskEnumUtil bitMaskUtil;
 
 	@Inject
-	public ReadWriteAdapter(@Named("root") Path root, @Named("maxFileNameLength") int maxFileNameLength, FileStore fileStore, LockManager lockManager, ReadWriteDirectoryHandler dirHandler, ReadWriteFileHandler fileHandler, ReadOnlyLinkHandler linkHandler, FileAttributesUtil attrUtil, BitMaskEnumUtil bitMaskUtil, OpenFileFactory fileFactory) {
-		super(root, maxFileNameLength, fileStore, lockManager, dirHandler, fileHandler, linkHandler, attrUtil, fileFactory);
+	public ReadWriteAdapter(@Named("root") Path root, @Named("maxFileNameLength") int maxFileNameLength, FileNameTranscoder fileNameTranscoder, FileStore fileStore, LockManager lockManager, ReadWriteDirectoryHandler dirHandler, ReadWriteFileHandler fileHandler, ReadOnlyLinkHandler linkHandler, FileAttributesUtil attrUtil, BitMaskEnumUtil bitMaskUtil, OpenFileFactory fileFactory) {
+		super(root, maxFileNameLength, fileNameTranscoder, fileStore, lockManager, dirHandler, fileHandler, linkHandler, attrUtil, fileFactory);
 		this.fileHandler = fileHandler;
 		this.attrUtil = attrUtil;
 		this.bitMaskUtil = bitMaskUtil;
@@ -335,5 +335,5 @@ public class ReadWriteAdapter extends ReadOnlyAdapter {
 			return -ErrorCodes.EIO();
 		}
 	}
-	
+
 }

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadWriteDirectoryHandler.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadWriteDirectoryHandler.java
@@ -11,8 +11,8 @@ import java.nio.file.attribute.PosixFileAttributes;
 public class ReadWriteDirectoryHandler extends ReadOnlyDirectoryHandler {
 
 	@Inject
-	public ReadWriteDirectoryHandler(FileAttributesUtil attrUtil) {
-		super(attrUtil);
+	public ReadWriteDirectoryHandler(FileAttributesUtil attrUtil, FileNameTranscoder fileNameTranscoder) {
+		super(attrUtil, fileNameTranscoder);
 	}
 
 	@Override

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/EnvironmentVariables.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/EnvironmentVariables.java
@@ -1,18 +1,20 @@
 package org.cryptomator.frontend.fuse.mount;
 
+import org.cryptomator.frontend.fuse.FileNameTranscoder;
+
 import java.nio.file.Path;
 import java.util.Optional;
 
 public class EnvironmentVariables {
 
 	private final Path mountPoint;
+	private final Optional<FileNameTranscoder> fileNameTranscoder;
 	private final String[] fuseFlags;
-	private final Optional<String> revealCommand;
 
-	private EnvironmentVariables(Path mountPoint, String[] fuseFlags, Optional<String> revealCommand) {
+	private EnvironmentVariables(Path mountPoint, String[] fuseFlags, Optional<FileNameTranscoder> fileNameTranscoder) {
 		this.mountPoint = mountPoint;
 		this.fuseFlags = fuseFlags;
-		this.revealCommand = revealCommand;
+		this.fileNameTranscoder = fileNameTranscoder;
 	}
 
 	public static EnvironmentVariablesBuilder create() {
@@ -27,15 +29,15 @@ public class EnvironmentVariables {
 		return fuseFlags;
 	}
 
-	public Optional<String> getRevealCommand() {
-		return revealCommand;
+	public Optional<FileNameTranscoder> getFileNameTranscoder() {
+		return fileNameTranscoder;
 	}
 
 	public static class EnvironmentVariablesBuilder {
 
 		private Path mountPoint = null;
 		private String[] fuseFlags;
-		private Optional<String> revealCommand = Optional.empty();
+		private Optional<FileNameTranscoder> fileNameTranscoder = Optional.empty();
 
 		public EnvironmentVariablesBuilder withMountPoint(Path mountPoint) {
 			this.mountPoint = mountPoint;
@@ -47,13 +49,13 @@ public class EnvironmentVariables {
 			return this;
 		}
 
-		public EnvironmentVariablesBuilder withRevealCommand(String revealCommand) {
-			this.revealCommand = Optional.ofNullable(revealCommand);
+		public EnvironmentVariablesBuilder withFileNameTranscoder(FileNameTranscoder fileNameTranscoder) {
+			this.fileNameTranscoder = Optional.of(fileNameTranscoder);
 			return this;
 		}
 
 		public EnvironmentVariables build() {
-			return new EnvironmentVariables(mountPoint, fuseFlags, revealCommand);
+			return new EnvironmentVariables(mountPoint, fuseFlags, fileNameTranscoder);
 		}
 
 	}

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/EnvironmentVariables.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/EnvironmentVariables.java
@@ -8,10 +8,10 @@ import java.util.Optional;
 public class EnvironmentVariables {
 
 	private final Path mountPoint;
-	private final Optional<FileNameTranscoder> fileNameTranscoder;
+	private final FileNameTranscoder fileNameTranscoder;
 	private final String[] fuseFlags;
 
-	private EnvironmentVariables(Path mountPoint, String[] fuseFlags, Optional<FileNameTranscoder> fileNameTranscoder) {
+	private EnvironmentVariables(Path mountPoint, String[] fuseFlags, FileNameTranscoder fileNameTranscoder) {
 		this.mountPoint = mountPoint;
 		this.fuseFlags = fuseFlags;
 		this.fileNameTranscoder = fileNameTranscoder;
@@ -29,7 +29,7 @@ public class EnvironmentVariables {
 		return fuseFlags;
 	}
 
-	public Optional<FileNameTranscoder> getFileNameTranscoder() {
+	public FileNameTranscoder getFileNameTranscoder() {
 		return fileNameTranscoder;
 	}
 
@@ -37,7 +37,7 @@ public class EnvironmentVariables {
 
 		private Path mountPoint = null;
 		private String[] fuseFlags;
-		private Optional<FileNameTranscoder> fileNameTranscoder = Optional.empty();
+		private FileNameTranscoder fileNameTranscoder;
 
 		public EnvironmentVariablesBuilder withMountPoint(Path mountPoint) {
 			this.mountPoint = mountPoint;
@@ -50,7 +50,7 @@ public class EnvironmentVariables {
 		}
 
 		public EnvironmentVariablesBuilder withFileNameTranscoder(FileNameTranscoder fileNameTranscoder) {
-			this.fileNameTranscoder = Optional.of(fileNameTranscoder);
+			this.fileNameTranscoder = fileNameTranscoder;
 			return this;
 		}
 

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/LinuxMounter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/LinuxMounter.java
@@ -1,6 +1,7 @@
 package org.cryptomator.frontend.fuse.mount;
 
 import org.cryptomator.frontend.fuse.AdapterFactory;
+import org.cryptomator.frontend.fuse.FileNameTranscoder;
 import org.cryptomator.frontend.fuse.FuseNioAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,7 +22,9 @@ class LinuxMounter implements Mounter {
 
 	@Override
 	public synchronized Mount mount(Path directory, boolean blocking, boolean debug, EnvironmentVariables envVars) throws CommandFailedException {
-		FuseNioAdapter fuseAdapter = AdapterFactory.createReadWriteAdapter(directory);
+		FuseNioAdapter fuseAdapter = AdapterFactory.createReadWriteAdapter(directory, //
+				AdapterFactory.DEFAULT_MAX_FILENAMELENGTH, //
+				envVars.getFileNameTranscoder().orElse(FileNameTranscoder.transcoder()));
 		try {
 			fuseAdapter.mount(envVars.getMountPoint(), blocking, debug, envVars.getFuseFlags());
 		} catch (RuntimeException e) {

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/LinuxMounter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/LinuxMounter.java
@@ -1,7 +1,6 @@
 package org.cryptomator.frontend.fuse.mount;
 
 import org.cryptomator.frontend.fuse.AdapterFactory;
-import org.cryptomator.frontend.fuse.FileNameTranscoder;
 import org.cryptomator.frontend.fuse.FuseNioAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,7 +23,7 @@ class LinuxMounter implements Mounter {
 	public synchronized Mount mount(Path directory, boolean blocking, boolean debug, EnvironmentVariables envVars) throws CommandFailedException {
 		FuseNioAdapter fuseAdapter = AdapterFactory.createReadWriteAdapter(directory, //
 				AdapterFactory.DEFAULT_MAX_FILENAMELENGTH, //
-				envVars.getFileNameTranscoder().orElse(FileNameTranscoder.transcoder()));
+				envVars.getFileNameTranscoder());
 		try {
 			fuseAdapter.mount(envVars.getMountPoint(), blocking, debug, envVars.getFuseFlags());
 		} catch (RuntimeException e) {

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/MacMounter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/MacMounter.java
@@ -42,7 +42,7 @@ class MacMounter implements Mounter {
 
 	@Override
 	public synchronized Mount mount(Path directory, boolean blocking, boolean debug, EnvironmentVariables envVars) throws CommandFailedException {
-		FileNameTranscoder macFileNameCoding = FileNameTranscoder.transcoder(StandardCharsets.UTF_8, StandardCharsets.UTF_8, Normalizer.Form.NFD, Normalizer.Form.NFC);
+		FileNameTranscoder macFileNameCoding = FileNameTranscoder.transcoder().withFuseNormalization(Normalizer.Form.NFD);
 		FuseNioAdapter fuseAdapter = AdapterFactory.createReadWriteAdapter(directory,254, macFileNameCoding);
 		try {
 			fuseAdapter.mount(envVars.getMountPoint(), blocking, debug, envVars.getFuseFlags());

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/MacMounter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/MacMounter.java
@@ -42,8 +42,9 @@ class MacMounter implements Mounter {
 
 	@Override
 	public synchronized Mount mount(Path directory, boolean blocking, boolean debug, EnvironmentVariables envVars) throws CommandFailedException {
-		FileNameTranscoder macFileNameCoding = FileNameTranscoder.transcoder().withFuseNormalization(Normalizer.Form.NFD);
-		FuseNioAdapter fuseAdapter = AdapterFactory.createReadWriteAdapter(directory,254, macFileNameCoding);
+		FuseNioAdapter fuseAdapter = AdapterFactory.createReadWriteAdapter(directory, //
+				AdapterFactory.DEFAULT_MAX_FILENAMELENGTH, //
+				envVars.getFileNameTranscoder().orElse(FileNameTranscoder.transcoder().withFuseNormalization(Normalizer.Form.NFD)));
 		try {
 			fuseAdapter.mount(envVars.getMountPoint(), blocking, debug, envVars.getFuseFlags());
 		} catch (RuntimeException e) {

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/MacMounter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/MacMounter.java
@@ -62,7 +62,6 @@ class MacMounter implements Mounter {
 					"-oatomic_o_trunc",
 					"-oauto_xattr",
 					"-oauto_cache",
-					"-omodules=iconv,from_code=UTF-8,to_code=UTF-8-MAC", // show files names in Unicode NFD encoding
 					"-onoappledouble", // vastly impacts performance for some reason...
 					"-odefault_permissions" // let the kernel assume permissions based on file attributes etc
 			};

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/MacMounter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/MacMounter.java
@@ -1,7 +1,7 @@
 package org.cryptomator.frontend.fuse.mount;
 
-import com.google.common.base.Preconditions;
 import org.cryptomator.frontend.fuse.AdapterFactory;
+import org.cryptomator.frontend.fuse.FileNameTranscoder;
 import org.cryptomator.frontend.fuse.FuseNioAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.text.Normalizer;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
@@ -41,7 +42,8 @@ class MacMounter implements Mounter {
 
 	@Override
 	public synchronized Mount mount(Path directory, boolean blocking, boolean debug, EnvironmentVariables envVars) throws CommandFailedException {
-		FuseNioAdapter fuseAdapter = AdapterFactory.createReadWriteAdapter(directory);
+		FileNameTranscoder macFileNameCoding = FileNameTranscoder.transcoder(StandardCharsets.UTF_8, StandardCharsets.UTF_8, Normalizer.Form.NFD, Normalizer.Form.NFC);
+		FuseNioAdapter fuseAdapter = AdapterFactory.createReadWriteAdapter(directory,254, macFileNameCoding);
 		try {
 			fuseAdapter.mount(envVars.getMountPoint(), blocking, debug, envVars.getFuseFlags());
 		} catch (RuntimeException e) {

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/MacMounter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/MacMounter.java
@@ -44,7 +44,7 @@ class MacMounter implements Mounter {
 	public synchronized Mount mount(Path directory, boolean blocking, boolean debug, EnvironmentVariables envVars) throws CommandFailedException {
 		FuseNioAdapter fuseAdapter = AdapterFactory.createReadWriteAdapter(directory, //
 				AdapterFactory.DEFAULT_MAX_FILENAMELENGTH, //
-				envVars.getFileNameTranscoder().orElse(FileNameTranscoder.transcoder().withFuseNormalization(Normalizer.Form.NFD)));
+				envVars.getFileNameTranscoder());
 		try {
 			fuseAdapter.mount(envVars.getMountPoint(), blocking, debug, envVars.getFuseFlags());
 		} catch (RuntimeException e) {
@@ -69,6 +69,11 @@ class MacMounter implements Mounter {
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		}
+	}
+
+	@Override
+	public FileNameTranscoder defaultFileNameTranscoder() {
+		return FileNameTranscoder.transcoder().withFuseNormalization(Normalizer.Form.NFD);
 	}
 
 	/**

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/Mounter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/Mounter.java
@@ -1,5 +1,7 @@
 package org.cryptomator.frontend.fuse.mount;
 
+import org.cryptomator.frontend.fuse.FileNameTranscoder;
+
 import java.nio.file.Path;
 
 public interface Mounter {
@@ -13,5 +15,9 @@ public interface Mounter {
 	String[] defaultMountFlags();
 
 	boolean isApplicable();
+
+	default FileNameTranscoder defaultFileNameTranscoder() {
+		return FileNameTranscoder.transcoder();
+	}
 
 }

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/WindowsMounter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/WindowsMounter.java
@@ -2,6 +2,7 @@ package org.cryptomator.frontend.fuse.mount;
 
 import jnr.ffi.Platform;
 import org.cryptomator.frontend.fuse.AdapterFactory;
+import org.cryptomator.frontend.fuse.FileNameTranscoder;
 import org.cryptomator.frontend.fuse.FuseNioAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,7 +18,9 @@ class WindowsMounter implements Mounter {
 
 	@Override
 	public synchronized Mount mount(Path directory, boolean blocking, boolean debug, EnvironmentVariables envVars) throws CommandFailedException {
-		FuseNioAdapter fuseAdapter = AdapterFactory.createReadWriteAdapter(directory);
+		FuseNioAdapter fuseAdapter = AdapterFactory.createReadWriteAdapter(directory, //
+				AdapterFactory.DEFAULT_MAX_FILENAMELENGTH, //
+				envVars.getFileNameTranscoder().orElse(FileNameTranscoder.transcoder()));
 		try {
 			fuseAdapter.mount(envVars.getMountPoint(), blocking, debug, envVars.getFuseFlags());
 		} catch (RuntimeException e) {

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/WindowsMounter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/WindowsMounter.java
@@ -2,7 +2,6 @@ package org.cryptomator.frontend.fuse.mount;
 
 import jnr.ffi.Platform;
 import org.cryptomator.frontend.fuse.AdapterFactory;
-import org.cryptomator.frontend.fuse.FileNameTranscoder;
 import org.cryptomator.frontend.fuse.FuseNioAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,7 +19,7 @@ class WindowsMounter implements Mounter {
 	public synchronized Mount mount(Path directory, boolean blocking, boolean debug, EnvironmentVariables envVars) throws CommandFailedException {
 		FuseNioAdapter fuseAdapter = AdapterFactory.createReadWriteAdapter(directory, //
 				AdapterFactory.DEFAULT_MAX_FILENAMELENGTH, //
-				envVars.getFileNameTranscoder().orElse(FileNameTranscoder.transcoder()));
+				envVars.getFileNameTranscoder());
 		try {
 			fuseAdapter.mount(envVars.getMountPoint(), blocking, debug, envVars.getFuseFlags());
 		} catch (RuntimeException e) {
@@ -44,7 +43,7 @@ class WindowsMounter implements Mounter {
 			String path = WinPathUtils.getWinFspPath(); //Result only matters for debug-message; null-check is included in lib
 			LOG.trace("Found WinFsp installation at {}", path);
 			return true;
-		} catch(FuseException exc) {
+		} catch (FuseException exc) {
 			LOG.debug("Failed to find a WinFsp installation; that's only a problem if you want to use FUSE on Windows. Exception text: \"{}\"", exc.getMessage());
 			return false;
 		}

--- a/src/test/java/org/cryptomator/frontend/fuse/FileNameTranscoderTest.java
+++ b/src/test/java/org/cryptomator/frontend/fuse/FileNameTranscoderTest.java
@@ -1,7 +1,140 @@
 package org.cryptomator.frontend.fuse;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
-//TODO
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.text.Normalizer;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.text.Normalizer.Form.NFC;
+import static java.text.Normalizer.Form.NFD;
+
 public class FileNameTranscoderTest {
+
+	private static final Charset COMPARSION_CS = StandardCharsets.UTF_16;
+	private MockedStatic<Normalizer> normalizerClass;
+
+	@BeforeEach
+	public void setup() {
+		normalizerClass = Mockito.mockStatic(Normalizer.class);
+		normalizerClass.when(() -> Normalizer.normalize(Mockito.any(), Mockito.any())).thenCallRealMethod();
+	}
+
+	@AfterEach
+	public void tearDown() {
+		normalizerClass.close();
+	}
+
+	@Nested
+	@DisplayName("UTF-8/NFC <-> UTF-8/NFC")
+	public class NoopTranscoder {
+
+		private FileNameTranscoder transcoder;
+
+		@BeforeEach
+		public void setup() {
+			this.transcoder = new FileNameTranscoder(UTF_8, UTF_8, NFC, NFC);
+		}
+
+		@ParameterizedTest
+		@DisplayName("fuseToNio()")
+		@ValueSource(strings = {"", "This is a test", "äöü", "🙂🐱"})
+		public void testNoopTranscodeFuseToNio(String str) {
+			String result = transcoder.fuseToNio(str);
+
+			normalizerClass.verifyNoInteractions();
+			Assertions.assertArrayEquals(str.getBytes(COMPARSION_CS), result.getBytes(COMPARSION_CS));
+		}
+
+		@ParameterizedTest
+		@DisplayName("nioToFuse()")
+		@ValueSource(strings = {"", "This is a test", "äöü", "🙂🐱"})
+		public void testNoopTranscodeNioToFuse(String str) {
+			String result = transcoder.nioToFuse(str);
+
+			normalizerClass.verifyNoInteractions();
+			Assertions.assertArrayEquals(str.getBytes(COMPARSION_CS), result.getBytes(COMPARSION_CS));
+		}
+
+	}
+
+	@Nested
+	@DisplayName("UTF-8/NFC <-> UTF-8/NFD")
+	public class TransNormalizer {
+
+		private FileNameTranscoder transcoder;
+
+		@BeforeEach
+		public void setup() {
+			this.transcoder = new FileNameTranscoder(UTF_8, UTF_8, NFD, NFC);
+		}
+
+		@ParameterizedTest
+		@DisplayName("fuseToNio()")
+		@ValueSource(strings = {"", "This is a test", "äöü", "🙂🐱"})
+		public void testNoopTranscodeFuseToNio(String str) {
+			String result = transcoder.fuseToNio(str);
+
+			normalizerClass.verify(() -> Normalizer.normalize(str, NFC));
+			Assertions.assertEquals(Normalizer.normalize(str, NFC), Normalizer.normalize(result, NFC));
+		}
+
+		@ParameterizedTest
+		@DisplayName("nioToFuse()")
+		@ValueSource(strings = {"", "This is a test", "äöü", "🙂🐱"})
+		public void testNoopTranscodeNioToFuse(String str) {
+			String result = transcoder.nioToFuse(str);
+
+			normalizerClass.verify(() -> Normalizer.normalize(str, NFD));
+			Assertions.assertEquals(Normalizer.normalize(str, NFC), Normalizer.normalize(result, NFC));
+		}
+
+	}
+
+	@Nested
+	@DisplayName("UTF-8 <-> ISO-8859-1")
+	public class ReEncoder {
+
+		private FileNameTranscoder transcoder;
+
+		@BeforeEach
+		public void setup() {
+			this.transcoder = new FileNameTranscoder(ISO_8859_1, UTF_8, NFC, NFC);
+		}
+
+		@ParameterizedTest
+		@DisplayName("toFuse(str) != str")
+		@ValueSource(strings = {"äöü", "🙂🐱"})
+		public void testTranscodeToLatin(String str) {
+			Assumptions.assumeTrue(str.chars().anyMatch(c -> c > 0x7F), "str does not contain multi-byte unicode character");
+
+			String fuseStr = transcoder.nioToFuse(str);
+
+			normalizerClass.verifyNoInteractions();
+			Assertions.assertNotEquals(str, fuseStr);
+		}
+
+		@ParameterizedTest
+		@DisplayName("toNio(toFuse(str)) == str")
+		@ValueSource(strings = {"", "This is a test", "äöü", "🙂🐱"})
+		public void testLosslessBackAndForth(String str) {
+			String result = transcoder.fuseToNio(transcoder.nioToFuse(str));
+
+			normalizerClass.verifyNoInteractions();
+			Assertions.assertEquals(str, result);
+		}
+
+	}
 
 }

--- a/src/test/java/org/cryptomator/frontend/fuse/FileNameTranscoderTest.java
+++ b/src/test/java/org/cryptomator/frontend/fuse/FileNameTranscoderTest.java
@@ -1,0 +1,51 @@
+package org.cryptomator.frontend.fuse;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.text.Normalizer;
+
+public class FileNameTranscoderTest {
+
+	private static final Charset COMPARSION_CS = StandardCharsets.UTF_16;
+
+	@Test
+	@DisplayName("Transcoding from a charset into itself without normalization does nothing")
+	public void testTranscodingFromCharsetToItselfDoesNothing(){
+		var transcodingCS = StandardCharsets.ISO_8859_1;
+		var fileNameTranscoder = FileNameTranscoder.transcoder(transcodingCS,transcodingCS);
+
+		String test = "This is a test";
+		byte [] before = test.getBytes(COMPARSION_CS);
+		byte [] after = fileNameTranscoder.fuseToNio(test).getBytes(COMPARSION_CS);
+
+		Assertions.assertArrayEquals(before, after);
+	}
+
+	@Test
+	@DisplayName("Normalization is only applied if src normalization != dst normalization")
+	public void testNoNormalizationIfSrcAndDstNormalizationIsSame(){
+		var transcodingCS = StandardCharsets.UTF_8;
+		var normalization = Normalizer.Form.NFD;
+		var fileNameTranscoder = FileNameTranscoder.transcoder(transcodingCS,transcodingCS, normalization, normalization);
+
+		String testString = "This is ä \uFA00";
+		byte [] before = testString.getBytes(COMPARSION_CS);
+		byte [] after = fileNameTranscoder.fuseToNio(testString).getBytes(COMPARSION_CS);
+
+		Assertions.assertArrayEquals(before,after);
+	}
+
+	@Test
+	@DisplayName("Creating a transcoder with non-null normalization and non-utf encoding fails")
+	public void testBuilderWithNormalizationFailsIfNoUTF(){
+		var csMock =Mockito.mock(Charset.class);
+		Mockito.when(csMock.displayName()).thenReturn("ISO88");
+		Assertions.assertThrows(IllegalArgumentException.class,() -> FileNameTranscoder.transcoder(csMock, csMock, Normalizer.Form.NFD,null));
+	}
+}

--- a/src/test/java/org/cryptomator/frontend/fuse/FileNameTranscoderTest.java
+++ b/src/test/java/org/cryptomator/frontend/fuse/FileNameTranscoderTest.java
@@ -1,51 +1,7 @@
 package org.cryptomator.frontend.fuse;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.text.Normalizer;
-
+//TODO
 public class FileNameTranscoderTest {
 
-	private static final Charset COMPARSION_CS = StandardCharsets.UTF_16;
-
-	@Test
-	@DisplayName("Transcoding from a charset into itself without normalization does nothing")
-	public void testTranscodingFromCharsetToItselfDoesNothing(){
-		var transcodingCS = StandardCharsets.ISO_8859_1;
-		var fileNameTranscoder = FileNameTranscoder.transcoder(transcodingCS,transcodingCS);
-
-		String test = "This is a test";
-		byte [] before = test.getBytes(COMPARSION_CS);
-		byte [] after = fileNameTranscoder.fuseToNio(test).getBytes(COMPARSION_CS);
-
-		Assertions.assertArrayEquals(before, after);
-	}
-
-	@Test
-	@DisplayName("Normalization is only applied if src normalization != dst normalization")
-	public void testNoNormalizationIfSrcAndDstNormalizationIsSame(){
-		var transcodingCS = StandardCharsets.UTF_8;
-		var normalization = Normalizer.Form.NFD;
-		var fileNameTranscoder = FileNameTranscoder.transcoder(transcodingCS,transcodingCS, normalization, normalization);
-
-		String testString = "This is ä \uFA00";
-		byte [] before = testString.getBytes(COMPARSION_CS);
-		byte [] after = fileNameTranscoder.fuseToNio(testString).getBytes(COMPARSION_CS);
-
-		Assertions.assertArrayEquals(before,after);
-	}
-
-	@Test
-	@DisplayName("Creating a transcoder with non-null normalization and non-utf encoding fails")
-	public void testBuilderWithNormalizationFailsIfNoUTF(){
-		var csMock =Mockito.mock(Charset.class);
-		Mockito.when(csMock.displayName()).thenReturn("ISO88");
-		Assertions.assertThrows(IllegalArgumentException.class,() -> FileNameTranscoder.transcoder(csMock, csMock, Normalizer.Form.NFD,null));
-	}
 }

--- a/src/test/java/org/cryptomator/frontend/fuse/mount/EnvironmentVariablesTest.java
+++ b/src/test/java/org/cryptomator/frontend/fuse/mount/EnvironmentVariablesTest.java
@@ -1,5 +1,6 @@
 package org.cryptomator.frontend.fuse.mount;
 
+import org.cryptomator.frontend.fuse.FileNameTranscoder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -11,11 +12,13 @@ public class EnvironmentVariablesTest {
 	@Test
 	public void testEnvironmentVariablesBuilder() {
 		String[] flags = new String[]{"--test", "--debug"};
+		FileNameTranscoder transcoder = FileNameTranscoder.transcoder();
 		Path mountPoint = Paths.get("/home/testuser/mnt");
 
-		EnvironmentVariables envVars = EnvironmentVariables.create().withFlags(flags).withMountPoint(mountPoint).build();
+		EnvironmentVariables envVars = EnvironmentVariables.create().withFlags(flags).withFileNameTranscoder(transcoder).withMountPoint(mountPoint).build();
 
 		Assertions.assertEquals(flags, envVars.getFuseFlags());
+		Assertions.assertEquals(transcoder, envVars.getFileNameTranscoder());
 		Assertions.assertEquals(mountPoint, envVars.getMountPoint());
 	}
 }

--- a/src/test/java/org/cryptomator/frontend/fuse/mount/LinuxEnvironmentTest.java
+++ b/src/test/java/org/cryptomator/frontend/fuse/mount/LinuxEnvironmentTest.java
@@ -16,7 +16,6 @@ public class LinuxEnvironmentTest {
 			EnvironmentVariables envVars = EnvironmentVariables.create()
 					.withFlags(mounter.defaultMountFlags())
 					.withMountPoint(mountPoint)
-					.withRevealCommand("nautilus")
 					.build();
 			Path tmp = Paths.get("/tmp");
 			try (Mount mnt = mounter.mount(tmp, envVars)) {

--- a/src/test/java/org/cryptomator/frontend/fuse/mount/MirroringFuseMountTest.java
+++ b/src/test/java/org/cryptomator/frontend/fuse/mount/MirroringFuseMountTest.java
@@ -181,6 +181,7 @@ public class MirroringFuseMountTest {
 		EnvironmentVariables envVars = EnvironmentVariables.create()
 				.withFlags(mounter.defaultMountFlags())
 				.withMountPoint(mountPoint)
+				.withFileNameTranscoder(mounter.defaultFileNameTranscoder())
 				.build();
 		try (Mount mnt = mounter.mount(pathToMirror, envVars)) {
 			LOG.info("Mounted successfully. Enter anything to stop the server...");

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Closes #56.

## Implemented Solution
Replacing the usage of the iconv-module by encoding/decoding strings in the FuseNioAdapter itself.

## Implementation Details
The new class `FileNameTranscoder` is added, which handles the encoding issues from Fuse to the nio layer and vice versa. If the desired target encoding requires normalization, it is also applied.

The class is integrated into the project by adding it as an instance variable of the `ReadOnlyAdapter` and can be set by calling the correct factory method of the `AdapterFactory`. All filename string passed from FUSE to the adapter are transcoded into the chosen nio charset. Additionally, fuse buffers are filled with correctly encoded strings.

For downstream projects, a transcoder can be created by using the `FileNameTranscoder.transcode()` factory method and the created object can be adjusted by calling one its `withXXX()` methods. Additionally, the mounter expose now the method `::defaultFileNameTranscoder` which returns a transcoder with the appropiate encoding _of the FUSE layer_.

## Remarks
This PR replaces #57 .

If the "normal" UTF-8-NFD encoding is sufficient needs to be tested. There is the possibility that we need aspecial NFD encoding scheme. (see https://developer.apple.com/library/archive/qa/qa1173/_index.html) A suitable testcharacter would be 切 (U+FA00).