### PR TITLE
Directly call fuse_exit for forced unmount in Windows and Linux

### DIFF
--- a/src/main/java/org/cryptomator/frontend/fuse/FuseNioAdapter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/FuseNioAdapter.java
@@ -36,4 +36,5 @@ public interface FuseNioAdapter extends FuseFS, AutoCloseable {
 	 */
 	void awaitInitCall(long timeOutMillis) throws InterruptedException, TimeoutException;
 
+	void unmountForced();
 }

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/LinuxMounter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/LinuxMounter.java
@@ -64,11 +64,7 @@ class LinuxMounter extends AbstractMounter {
 			if (!fuseAdapter.isMounted()) {
 				return;
 			}
-			ProcessBuilder command = new ProcessBuilder("fusermount", "-u", "-z", "--", mountPoint.getFileName().toString());
-			command.directory(mountPoint.getParent().toFile());
-			Process proc = ProcessUtil.startAndWaitFor(command, 5, TimeUnit.SECONDS);
-			assertUmountSucceeded(proc);
-			fuseAdapter.setUnmounted();
+			fuseAdapter.unmountForced();
 		}
 
 		private void assertUmountSucceeded(Process proc) throws FuseMountException {

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/WindowsMounter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/WindowsMounter.java
@@ -54,7 +54,7 @@ class WindowsMounter extends AbstractMounter {
 
 		@Override
 		protected void unmountForcedInternal() {
-			unmountInternal();
+			fuseAdapter.unmountForced();
 		}
 
 	}


### PR DESCRIPTION
closes #61

* extend FuseNioAdapter interface with unmountForced() method
* implement method in ReadOnlyAdapter
* let Linux- and WindowsMount use the method

The MacMount `unmountForced()` is not changed.