### PR TITLE
Review OpenFile#read methods

### DIFF
--- a/src/main/java/org/cryptomator/frontend/fuse/OpenFile.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/OpenFile.java
@@ -16,107 +16,101 @@ import org.slf4j.LoggerFactory;
 
 public class OpenFile implements Closeable {
 
-	private static final Logger LOG = LoggerFactory.getLogger(OpenFile.class);
-	private static final int BUFFER_SIZE = 4096;
+    private static final Logger LOG = LoggerFactory.getLogger(OpenFile.class);
+    private static final int BUFFER_SIZE = 4096;
 
-	private final Path path;
-	private final FileChannel channel;
+    private final Path path;
+    private final FileChannel channel;
 
-	private OpenFile(Path path, FileChannel channel) {
-		this.path = path;
-		this.channel = channel;
-	}
-	
-	static OpenFile create(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs) throws IOException {
-		FileChannel ch = FileChannel.open(path, options, attrs);
-		return new OpenFile(path, ch);
-	}
+    private OpenFile(Path path, FileChannel channel) {
+        this.path = path;
+        this.channel = channel;
+    }
 
-	/**
-	 * Reads up to {@code num} bytes beginning at {@code offset} into {@code buf}
-	 *
-	 * @param buf Buffer
-	 * @param num Number of bytes to read
-	 * @param offset Position of first byte to read
-	 * @return Actual number of bytes read (can be less than {@code size} if reached EOF).
-	 * @throws IOException If an exception occurs during read.
-	 */
-	public synchronized int read(Pointer buf, long num, long offset) throws IOException {
-		long size = channel.size();
-		if (offset >= size) {
-			return 0;
-		} else {
-			ByteBuffer bb = ByteBuffer.allocate(BUFFER_SIZE);
-			long pos = 0;
-			channel.position(offset);
-			LOG.trace("Attempting to read {}-{}:", offset, offset + num);
-			do {
-				long remaining = num - pos;
-				int read = readNext(bb, remaining);
-				if (read == -1) {
-					LOG.trace("Reached EOF");
-					return (int) pos; // reached EOF TODO: wtf cast
-				} else {
-					LOG.trace("Reading {}-{}", offset + pos, offset + pos + read);
-					buf.put(pos, bb.array(), 0, read);
-					pos += read;
-				}
-			} while (pos < num);
-			return (int) pos; // TODO wtf cast
-		}
-	}
+    static OpenFile create(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs) throws IOException {
+        FileChannel ch = FileChannel.open(path, options, attrs);
+        return new OpenFile(path, ch);
+    }
 
-	/**
-	 * Writes up to {@code num} bytes from {@code buf} from {@code offset} into the current file
-	 *
-	 * @param buf Buffer
-	 * @param num Number of bytes to write
-	 * @param offset Position of first byte to write at
-	 * @return Actual number of bytes written
-	 *         TODO: only the bytes which contains information or also some filling zeros?
-	 * @throws IOException If an exception occurs during write.
-	 */
-	public synchronized int write(Pointer buf, long num, long offset) throws IOException {
-		ByteBuffer bb = ByteBuffer.allocate(BUFFER_SIZE);
-		long written = 0;
-		channel.position(offset);
-		do {
-			long remaining = num - written;
-			bb.clear();
-			int len = (int) Math.min(remaining, bb.capacity());
-			buf.get(written, bb.array(), 0, len);
-			bb.limit(len);
-			channel.write(bb); // TODO check return value
-			written += len;
-		} while (written < num);
-		return (int) written; // TODO wtf cast
-	}
+    /**
+     * Reads up to {@code num} bytes beginning at {@code offset} into {@code buf}
+     *
+     * @param buf Buffer
+     * @param num Number of bytes to read
+     * @param offset Position of first byte to read
+     * @return Actual number of bytes read (can be less than {@code size} if reached EOF).
+     * @throws IOException If an exception occurs during read.
+     */
+    public synchronized int read(Pointer buf, long num, long offset) throws IOException {
+        num = Math.min(channel.size() - offset, num);
 
-	private int readNext(ByteBuffer readBuf, long num) throws IOException {
-		readBuf.clear();
-		readBuf.limit((int) Math.min(readBuf.capacity(), num));
-		return channel.read(readBuf);
-	}
+        ByteBuffer bb = ByteBuffer.allocate(BUFFER_SIZE);
+        long pos = 0;
+        channel.position(offset);
 
-	@Override
-	public void close() throws IOException {
-		channel.close();
-	}
+        LOG.trace("Attempting to read {}-{}:", offset, offset + num);
+        do {
+            long remaining = num - pos;
+            int read = readNext(bb, remaining);
 
-	public void fsync(boolean metaData) throws IOException {
-		channel.force(metaData);
-	}
+            LOG.trace("Reading {}-{}", offset + pos, offset + pos + read);
+            buf.put(pos, bb.array(), 0, read);
+            pos += read;
+        } while (pos < num);
+        return (int) pos; // TODO wtf cast
+    }
 
-	public void truncate(long size) throws IOException {
-		FileChannelUtil.truncateOrExpand(channel, size);
-	}
+    /**
+     * Writes up to {@code num} bytes from {@code buf} from {@code offset} into the current file
+     *
+     * @param buf Buffer
+     * @param num Number of bytes to write
+     * @param offset Position of first byte to write at
+     * @return Actual number of bytes written
+     *         TODO: only the bytes which contains information or also some filling zeros?
+     * @throws IOException If an exception occurs during write.
+     */
+    public synchronized int write(Pointer buf, long num, long offset) throws IOException {
+        ByteBuffer bb = ByteBuffer.allocate(BUFFER_SIZE);
+        long written = 0;
+        channel.position(offset);
+        do {
+            long remaining = num - written;
+            bb.clear();
+            int len = (int) Math.min(remaining, bb.capacity());
+            buf.get(written, bb.array(), 0, len);
+            bb.limit(len);
+            channel.write(bb); // TODO check return value
+            written += len;
+        } while (written < num);
+        return (int) written; // TODO wtf cast
+    }
 
-	@Override
-	public String toString() {
-		return MoreObjects.toStringHelper(OpenFile.class) //
-				.add("path", path) //
-				.add("channel", channel) //
-				.toString();
-	}
+    private int readNext(ByteBuffer readBuf, long num) throws IOException {
+        readBuf.clear();
+        readBuf.limit((int) Math.min(readBuf.capacity(), num));
+        return channel.read(readBuf);
+    }
+
+    @Override
+    public void close() throws IOException {
+        channel.close();
+    }
+
+    public void fsync(boolean metaData) throws IOException {
+        channel.force(metaData);
+    }
+
+    public void truncate(long size) throws IOException {
+        FileChannelUtil.truncateOrExpand(channel, size);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(OpenFile.class) //
+                .add("path", path) //
+                .add("channel", channel) //
+                .toString();
+    }
 
 }


### PR DESCRIPTION
# Actual state

Actually, the case where **EOF** is reached during the read is impossible. However, there is verification to protect this case.

# The update

The inspiration comes from [SerCeMan - jnr-fuse/.../MemoryFS.java (line 125)](https://github.com/SerCeMan/jnr-fuse/blob/master/src/main/java/ru/serce/jnrfuse/examples/MemoryFS.java#L125)

Update the **OpenFile#read method** to incread code readability, to avoid to reach EOF and try to **read the maximum of possible bytes**.

To do that, re-evaluate the _num_ value by choosing the min value between the given _num_ and the actual _channel.size()_ minus the given _offset_. 

```java
public int read(Pointer buf, long num, long offset) {
    num = Math.min(channel.size() - offset, num);

    ...

    return pos;
}
```

In that way it is not possible to exceed the EOF and number of bytes read returned is always correct.

# Other update

Remove this verification:

```java
if (offset >= size) {
    return 0;
}
````

It seems to be an impossible case.
