### PR TITLE
Review OpenFile#read methods

### DIFF
--- a/src/main/java/org/cryptomator/frontend/fuse/OpenFile.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/OpenFile.java
@@ -46,6 +46,7 @@ public class OpenFile implements Closeable {
 		if (offset >= size) {
 			return 0;
 		} else {
+			num = Math.min(size - offset, num);
 			ByteBuffer bb = ByteBuffer.allocate(BUFFER_SIZE);
 			long pos = 0;
 			channel.position(offset);
@@ -53,14 +54,9 @@ public class OpenFile implements Closeable {
 			do {
 				long remaining = num - pos;
 				int read = readNext(bb, remaining);
-				if (read == -1) {
-					LOG.trace("Reached EOF");
-					return (int) pos; // reached EOF TODO: wtf cast
-				} else {
-					LOG.trace("Reading {}-{}", offset + pos, offset + pos + read);
-					buf.put(pos, bb.array(), 0, read);
-					pos += read;
-				}
+				LOG.trace("Reading {}-{}", offset + pos, offset + pos + read);
+				buf.put(pos, bb.array(), 0, read);
+				pos += read;
 			} while (pos < num);
 			return (int) pos; // TODO wtf cast
 		}


### PR DESCRIPTION
# Actual state

Actually, in the read `do while` loop, **EOF** reach verification is done. However is is not very readable and an additional loop round is done just to verify if **EOF** has been reached.

# The update

The inspiration comes from [SerCeMan - jnr-fuse/.../MemoryFS.java (line 125)](https://github.com/SerCeMan/jnr-fuse/blob/master/src/main/java/ru/serce/jnrfuse/examples/MemoryFS.java#L125)

Update the **OpenFile#read method** to incread code readability, to avoid to reach EOF and try to **read the maximum of possible bytes**.

To do that, re-evaluate the _num_ value by choosing the min value between the given _num_ and the actual _channel.size()_ minus the given _offset_. 

```java
public int read(Pointer buf, long num, long offset) {
    num = Math.min(channel.size() - offset, num);

    ...

    return pos;
}
```

In that way it is not possible to exceed the EOF and number of bytes read returned is always correct.
