### PR TITLE
Remove guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,7 @@
             <version>${integrations-api.version}</version>
         </dependency>
 
-        <!-- Guava -->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
+        <!-- Cache -->
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
         <!-- dependencies -->
         <integrations-api.version>1.2.0</integrations-api.version>
         <jfuse.version>0.5.1</jfuse.version>
-        <guava.version>31.1-jre</guava.version>
         <slf4j.version>2.0.7</slf4j.version>
         <caffeine.version>3.1.6</caffeine.version>
 

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -9,7 +9,6 @@ module org.cryptomator.frontend.fuse {
 	requires org.cryptomator.jfuse;
 	requires org.cryptomator.integrations.api;
 	requires org.slf4j;
-	requires com.google.common; // TODO try to remove
 	requires com.github.benmanes.caffeine;
 	requires static org.jetbrains.annotations;
 

--- a/src/main/java/org/cryptomator/frontend/fuse/FileNameTranscoder.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/FileNameTranscoder.java
@@ -1,11 +1,10 @@
 package org.cryptomator.frontend.fuse;
 
-import com.google.common.base.Preconditions;
-
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
+import java.util.Objects;
 
 /**
  * Class to transcode filenames and path components from one encoding to another.
@@ -25,10 +24,10 @@ public class FileNameTranscoder {
 	private final boolean nioCharsetIsUnicode;
 
 	FileNameTranscoder(Charset fuseCharset, Charset nioCharset, Normalizer.Form fuseNormalization, Normalizer.Form nioNormalization) {
-		this.fuseCharset = Preconditions.checkNotNull(fuseCharset);
-		this.nioCharset = Preconditions.checkNotNull(nioCharset);
-		this.fuseNormalization = Preconditions.checkNotNull(fuseNormalization);
-		this.nioNormalization = Preconditions.checkNotNull(nioNormalization);
+		this.fuseCharset = Objects.requireNonNull(fuseCharset);
+		this.nioCharset = Objects.requireNonNull(nioCharset);
+		this.fuseNormalization = Objects.requireNonNull(fuseNormalization);
+		this.nioNormalization = Objects.requireNonNull(nioNormalization);
 		this.fuseCharsetIsUnicode = fuseCharset.name().startsWith("UTF");
 		this.nioCharsetIsUnicode = nioCharset.name().startsWith("UTF");
 	}

--- a/src/main/java/org/cryptomator/frontend/fuse/OpenFile.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/OpenFile.java
@@ -1,6 +1,5 @@
 package org.cryptomator.frontend.fuse;
 
-import com.google.common.base.MoreObjects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,10 +96,10 @@ public class OpenFile implements Closeable {
 
 	@Override
 	public String toString() {
-		return MoreObjects.toStringHelper(OpenFile.class) //
-				.add("path", path) //
-				.add("channel", channel) //
-				.toString();
+		return "OpenFile{"
+				+ "path=" + path + ", "
+				+ "channel=" + channel
+				+ "}";
 	}
 
 }

--- a/src/main/java/org/cryptomator/frontend/fuse/OpenFileFactory.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/OpenFileFactory.java
@@ -1,6 +1,5 @@
 package org.cryptomator.frontend.fuse;
 
-import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,8 +8,6 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
-import java.util.Iterator;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -30,7 +27,7 @@ public class OpenFileFactory implements AutoCloseable {
 	 * @throws IOException
 	 */
 	public long open(Path path, OpenOption... options) throws IOException {
-		return this.open(path, Sets.newHashSet(options));
+		return open(path, Set.of(options));
 	}
 
 	/**

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyDirectoryHandler.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyDirectoryHandler.java
@@ -1,19 +1,17 @@
 package org.cryptomator.frontend.fuse;
 
-import com.google.common.collect.Iterators;
 import org.cryptomator.jfuse.api.DirFiller;
 import org.cryptomator.jfuse.api.FileInfo;
 import org.cryptomator.jfuse.api.Stat;
 
 import java.io.IOException;
 import java.nio.file.DirectoryIteratorException;
-import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFileAttributes;
-import java.util.Iterator;
+import java.util.stream.Stream;
 
 public class ReadOnlyDirectoryHandler {
 
@@ -61,11 +59,11 @@ public class ReadOnlyDirectoryHandler {
 //		}
 
 		// just fill in names, getattr gets called for each entry anyway
-		try (DirectoryStream<Path> ds = Files.newDirectoryStream(path)) {
-			Iterator<Path> sameAndParent = Iterators.forArray(SAME_DIR, PARENT_DIR);
-			Iterator<Path> iter = Iterators.concat(sameAndParent, ds.iterator());
-			while (iter.hasNext()) {
-				String fileName = iter.next().getFileName().toString();
+		try (Stream<Path> ds = Files.list(path)) {
+			Stream<Path> sameAndParent = Stream.of(SAME_DIR, PARENT_DIR);
+			Stream<Path> iter = Stream.concat(sameAndParent, ds);
+			for (Path file : iter.toList()) {
+				String fileName = file.getFileName().toString();
 				filler.fill(fileNameTranscoder.nioToFuse(fileName));
 			}
 			return 0;

--- a/src/main/java/org/cryptomator/frontend/fuse/locks/FilePaths.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/locks/FilePaths.java
@@ -1,35 +1,40 @@
 package org.cryptomator.frontend.fuse.locks;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 class FilePaths {
 
-	private static final char PATH_SEP = '/';
+	private static final String PATH_SEP = "/";
 	private static final String ROOT = "";
-	private static final Splitter PATH_SPLITTER = Splitter.on(PATH_SEP).omitEmptyStrings();
-	private static final Joiner PATH_JOINER = Joiner.on(PATH_SEP);
+	private static final Pattern PATH_REGEX = Pattern.compile(PATH_SEP);
 
 	@Unmodifiable
 	public static List<String> toComponents(String pathRelativeToRoot) {
-		return Stream.concat(Stream.of(ROOT), PATH_SPLITTER.splitToStream(pathRelativeToRoot)).toList();
+		return Stream.concat(Stream.of(ROOT), PATH_REGEX
+				.splitAsStream(pathRelativeToRoot)
+				.filter(Predicate.not(String::isEmpty))).toList();
 	}
 
 	public static String toPath(List<String> pathComponents) {
-		return PATH_JOINER.join(pathComponents);
+		return String.join(PATH_SEP, pathComponents);
 	}
 
 	public static List<String> parentPathComponents(List<String> pathComponents) {
-		assert pathComponents.size() > 0;
+		assert !pathComponents.isEmpty();
 		return pathComponents.subList(0, pathComponents.size() - 1);
 	}
 
 	public static String normalizePath(String path) {
-		return ROOT + PATH_SEP + PATH_JOINER.join(PATH_SPLITTER.split(path));
+		return ROOT + PATH_SEP + PATH_REGEX
+				.splitAsStream(path)
+				.filter(Predicate.not(String::isEmpty))
+				.collect(Collectors.joining(PATH_SEP));
 	}
 
 }

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/FuseTMountProvider.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/FuseTMountProvider.java
@@ -1,6 +1,5 @@
 package org.cryptomator.frontend.fuse.mount;
 
-import com.google.common.base.Preconditions;
 import org.cryptomator.frontend.fuse.FileNameTranscoder;
 import org.cryptomator.frontend.fuse.FuseNioAdapter;
 import org.cryptomator.frontend.fuse.ReadWriteAdapter;
@@ -21,6 +20,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.Normalizer;
 import java.util.EnumSet;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.cryptomator.integrations.mount.MountCapability.MOUNT_FLAGS;
@@ -114,8 +114,8 @@ public class FuseTMountProvider implements MountService {
 
 		@Override
 		public Mount mount() throws MountFailedException {
-			Preconditions.checkNotNull(mountPoint);
-			Preconditions.checkNotNull(mountFlags);
+			Objects.requireNonNull(mountPoint);
+			Objects.requireNonNull(mountFlags);
 
 			var builder = Fuse.builder();
 			builder.setLibraryPath(DYLIB_PATH);

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/LinuxFuseMountProvider.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/LinuxFuseMountProvider.java
@@ -1,6 +1,5 @@
 package org.cryptomator.frontend.fuse.mount;
 
-import com.google.common.base.Preconditions;
 import org.cryptomator.frontend.fuse.FileNameTranscoder;
 import org.cryptomator.frontend.fuse.FuseNioAdapter;
 import org.cryptomator.frontend.fuse.ReadWriteAdapter;
@@ -24,6 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
@@ -42,7 +42,7 @@ public class LinuxFuseMountProvider implements MountService {
 	private static final String[] LIB_PATHS = {
 			"/usr/lib/libfuse3.so", // default
 			"/lib/x86_64-linux-gnu/libfuse3.so.3", // debian amd64
-			"/lib/aarch64-linux-gnu/libfuse3.so.3", // debiant aarch64
+			"/lib/aarch64-linux-gnu/libfuse3.so.3", // debian aarch64
 			"/usr/lib64/libfuse3.so.3", // fedora
 			"/app/lib/libfuse3.so" // flatpak
 	};
@@ -98,8 +98,8 @@ public class LinuxFuseMountProvider implements MountService {
 
 		@Override
 		public Mount mount() throws MountFailedException {
-			Preconditions.checkNotNull(mountPoint);
-			Preconditions.checkNotNull(mountFlags);
+			Objects.requireNonNull(mountPoint);
+			Objects.requireNonNull(mountFlags);
 
 			var libPath = Arrays.stream(LIB_PATHS).map(Path::of).filter(Files::exists).map(Path::toString).findAny().orElseThrow();
 			var builder = Fuse.builder();

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/MacFuseMountProvider.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/MacFuseMountProvider.java
@@ -1,6 +1,5 @@
 package org.cryptomator.frontend.fuse.mount;
 
-import com.google.common.base.Preconditions;
 import org.cryptomator.frontend.fuse.FileNameTranscoder;
 import org.cryptomator.frontend.fuse.FuseNioAdapter;
 import org.cryptomator.frontend.fuse.ReadWriteAdapter;
@@ -21,6 +20,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.Normalizer;
 import java.util.EnumSet;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.cryptomator.integrations.mount.MountCapability.MOUNT_FLAGS;
@@ -106,9 +106,9 @@ public class MacFuseMountProvider implements MountService {
 
 		@Override
 		public Mount mount() throws MountFailedException {
-			Preconditions.checkNotNull(mountFlags);
+			Objects.requireNonNull(mountFlags);
 			if (mountPoint == null) {
-				Preconditions.checkNotNull(volumeId);
+				Objects.requireNonNull(volumeId);
 				mountPoint = Path.of("/Volumes/", volumeId);
 			}
 

--- a/suppression.xml
+++ b/suppression.xml
@@ -41,12 +41,4 @@
         <!-- Can't fix: Error in FUSE/Not of technical concern for this library -->
         <cve>CVE-2018-10906</cve>
     </suppress>
-    <suppress>
-        <notes><![CDATA[
-  		Suppress false positive, because com.google.common.io.Files.getTempDir() is not used
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
-        <vulnerabilityName>CVE-2020-8908</vulnerabilityName>
-        <cve>CVE-2020-8908</cve>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
Follow-up to https://github.com/cryptomator/fuse-nio-adapter/pull/70 and https://github.com/cryptomator/fuse-nio-adapter/pull/71, removes guava as a dependency. In a few cases where there isn't an exact replacement in the jdk, I've substituted the existing code with something else.

Biggest things to scrutinize:
* The strip leading `/` characters from method using a StringBuilder
* The DirectoryStream to Stream migration
* The Splitter/Joiner replacement