### PR TITLE
Feature: Redefine "inUse" definition

### DIFF
--- a/src/main/java/org/cryptomator/frontend/fuse/FuseNioAdapter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/FuseNioAdapter.java
@@ -12,6 +12,13 @@ public interface FuseNioAdapter extends FuseOperations, AutoCloseable {
 	int DEFAULT_MAX_FILENAMELENGTH = 254; // 255 is preferred, but nautilus checks for this value + 1
 
 	/**
+	 * The default value until an {@link OpenFile} is considered active.
+	 * 
+	 * @see OpenFileFactory#hasActiveFiles(long) 
+	 */
+	long DEFAULT_ACTIVE_THRESHOLD = Long.MAX_VALUE;
+
+	/**
 	 * Checks if the filesystem is in use (and therefore an unmount attempt should be avoided).
 	 * <p>
 	 * Important: This function only checks, like the name suggests, if the filesystem is busy and used. A return value of {@code false} should not be considered as an unmount can be safely and successfully executed and thus an unmount may fail.

--- a/src/main/java/org/cryptomator/frontend/fuse/OpenFile.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/OpenFile.java
@@ -12,7 +12,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
 import java.time.Instant;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class OpenFile implements Closeable {
 
@@ -20,13 +20,13 @@ public class OpenFile implements Closeable {
 
 	private final Path path;
 	private final FileChannel channel;
-	private final AtomicReference<Instant> lastUsed = new AtomicReference(Instant.now());
+	private final AtomicLong lastUsed = new AtomicLong(Instant.now().toEpochMilli());
 
 	private OpenFile(Path path, FileChannel channel) {
 		this.path = path;
 		this.channel = channel;
 	}
-	
+
 	static OpenFile create(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs) throws IOException {
 		FileChannel ch = FileChannel.open(path, options, attrs);
 		return new OpenFile(path, ch);
@@ -42,7 +42,7 @@ public class OpenFile implements Closeable {
 	 * @throws IOException If an exception occurs during read.
 	 */
 	public int read(ByteBuffer buf, long num, long offset) throws IOException {
-		lastUsed.set(Instant.now());
+		lastUsed.set(Instant.now().toEpochMilli());
 		long size = channel.size();
 		if (offset >= size) {
 			return 0;
@@ -73,7 +73,7 @@ public class OpenFile implements Closeable {
 	 * @throws IOException If an exception occurs during write.
 	 */
 	public int write(ByteBuffer buf, long num, long offset) throws IOException {
-		lastUsed.set(Instant.now());
+		lastUsed.set(Instant.now().toEpochMilli());
 		if (num > Integer.MAX_VALUE) {
 			throw new IOException("Requested too many bytes");
 		}
@@ -86,7 +86,7 @@ public class OpenFile implements Closeable {
 	}
 
 	public Instant lastUsed() {
-		return lastUsed.get();
+		return Instant.ofEpochMilli(lastUsed.get());
 	}
 
 	@Override

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadWriteAdapter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadWriteAdapter.java
@@ -38,21 +38,25 @@ public final class ReadWriteAdapter extends ReadOnlyAdapter {
 	private static final Logger LOG = LoggerFactory.getLogger(ReadWriteAdapter.class);
 	private final ReadWriteFileHandler fileHandler;
 
-	private ReadWriteAdapter(Errno errno, Path root, int maxFileNameLength, FileNameTranscoder fileNameTranscoder, FileStore fileStore, OpenFileFactory openFiles, ReadWriteDirectoryHandler dirHandler, ReadWriteFileHandler fileHandler) {
-		super(errno, root, maxFileNameLength, fileNameTranscoder, fileStore, openFiles, dirHandler, fileHandler);
+	private ReadWriteAdapter(Errno errno, Path root, int maxFileNameLength, FileNameTranscoder fileNameTranscoder, FileStore fileStore, OpenFileFactory openFiles, long activeOpenFileThreshold, ReadWriteDirectoryHandler dirHandler, ReadWriteFileHandler fileHandler) {
+		super(errno, root, maxFileNameLength, fileNameTranscoder, fileStore, openFiles, activeOpenFileThreshold, dirHandler, fileHandler);
 		this.fileHandler = fileHandler;
 	}
 
-	public static ReadWriteAdapter create(Errno errno, Path root, int maxFileNameLength, FileNameTranscoder fileNameTranscoder) {
+	public static ReadWriteAdapter create(Errno errno, Path root, int maxFileNameLength, FileNameTranscoder fileNameTranscoder, long activeOpenFileThreshold) {
 		try {
 			var fileStore = Files.getFileStore(root);
 			var openFiles = new OpenFileFactory();
 			var dirHandler = new ReadWriteDirectoryHandler(fileNameTranscoder);
 			var fileHandler = new ReadWriteFileHandler(openFiles);
-			return new ReadWriteAdapter(errno, root, maxFileNameLength, fileNameTranscoder, fileStore, openFiles, dirHandler, fileHandler);
+			return new ReadWriteAdapter(errno, root, maxFileNameLength, fileNameTranscoder, fileStore, openFiles, activeOpenFileThreshold, dirHandler, fileHandler);
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		}
+	}
+
+	public static ReadWriteAdapter create(Errno errno, Path root, int maxFileNameLength, FileNameTranscoder fileNameTranscoder) {
+		return create(errno, root, maxFileNameLength, fileNameTranscoder, DEFAULT_ACTIVE_THRESHOLD);
 	}
 
 	@Override


### PR DESCRIPTION
This PR redefines the "in use" definition introduced in https://github.com/cryptomator/fuse-nio-adapter/pull/48.

Instead of just counting the opened files, it introduces the notion of _active_ ( or _stale_ respectively) open files. An open file is active, if within the last `X` seconds its `read()` or `write()` method were called. `X` is a filesystem specifc threshold and can be set in during the fs creation.

This redefintion is motivated by Windows/WinFsp behavior: It seems, that on Windows there are processes keeping file handles open, even though they are not used anymore until `unmount()`. 
For examples, there are the following user reports:
* https://github.com/cryptomator/cryptomator/issues/3043, 
* https://www.reddit.com/r/Cryptomator/comments/11ovkhn/found_a_bug_while_trying_to_fix_a_lock_failed/ or 
* https://community.cryptomator.org/t/lock-fails-if-vault-contains-exe-file-that-is-accessed/11418).