### PR TITLE
Relaxed inUse definition

### DIFF
--- a/src/main/java/org/cryptomator/frontend/fuse/OpenFile.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/OpenFile.java
@@ -90,7 +90,8 @@ public class OpenFile implements Closeable {
 	}
 
 	/**
-	 * Tests, if the write method of this open file was called at least once.
+	 * Tests, if this OpenFile is <em>dirty</em>.
+	 * An OpenFile is dirty, if its write method is called at least once.
 	 *
 	 * @return {@code true} if {@link OpenFile#write(ByteBuffer, long, long)} was called on this object, otherwise {@code false}
 	 */

--- a/src/main/java/org/cryptomator/frontend/fuse/OpenFile.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/OpenFile.java
@@ -19,12 +19,12 @@ public class OpenFile implements Closeable {
 	private final Path path;
 	private final FileChannel channel;
 
-	private volatile boolean writeCalled;
+	private volatile boolean dirty;
 
 	private OpenFile(Path path, FileChannel channel) {
 		this.path = path;
 		this.channel = channel;
-		this.writeCalled = false;
+		this.dirty = false;
 	}
 
 	static OpenFile create(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs) throws IOException {
@@ -72,7 +72,7 @@ public class OpenFile implements Closeable {
 	 * @throws IOException If an exception occurs during write.
 	 */
 	public int write(ByteBuffer buf, long num, long offset) throws IOException {
-		writeCalled = true;
+		dirty = true;
 		if (num > Integer.MAX_VALUE) {
 			throw new IOException("Requested too many bytes");
 		}
@@ -89,8 +89,8 @@ public class OpenFile implements Closeable {
 	 *
 	 * @return {@code true} if {@link OpenFile#write(ByteBuffer, long, long)} was called on this object, otherwise {@code false}
 	 */
-	public boolean isWrittenTo() {
-		return writeCalled;
+	boolean isDirty() {
+		return dirty;
 	}
 
 	@Override

--- a/src/main/java/org/cryptomator/frontend/fuse/OpenFile.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/OpenFile.java
@@ -19,6 +19,7 @@ public class OpenFile implements Closeable {
 	private final Path path;
 	private final FileChannel channel;
 
+	//"volatile" is fine, since methods of OpenFile ar externally synchronized
 	private volatile boolean dirty;
 
 	private OpenFile(Path path, FileChannel channel) {

--- a/src/main/java/org/cryptomator/frontend/fuse/OpenFile.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/OpenFile.java
@@ -100,6 +100,7 @@ public class OpenFile implements Closeable {
 
 	public void fsync(boolean metaData) throws IOException {
 		channel.force(metaData);
+		dirty = false;
 	}
 
 	public void truncate(long size) throws IOException {

--- a/src/main/java/org/cryptomator/frontend/fuse/OpenFile.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/OpenFile.java
@@ -19,7 +19,11 @@ public class OpenFile implements Closeable {
 	private final Path path;
 	private final FileChannel channel;
 
-	//"volatile" is fine, since methods of OpenFile ar externally synchronized
+	/**
+	 * Whether any data has been changed on this file.
+	 *
+	 * This value only changes while holding a write lock, see {@link org.cryptomator.frontend.fuse.locks.LockManager}.
+	 */
 	private volatile boolean dirty;
 
 	private OpenFile(Path path, FileChannel channel) {

--- a/src/main/java/org/cryptomator/frontend/fuse/OpenFileFactory.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/OpenFileFactory.java
@@ -68,13 +68,14 @@ public class OpenFileFactory implements AutoCloseable {
 	}
 
 	/**
-	 * Tests, if there exists {@link OpenFile}s, which has been written to.
-	 * The check performed in this method is not atomic and therefore requires external synchronization.
+	 * Tests, if there exists dirty {@link OpenFile}s
+	 * This method is neither atomic regarding the set of open files nor regarding each open file individually. Therefore, external synchronization is required.
 	 *
-	 * @return {@code true} if and only if at least one {@link OpenFile} exists, where {@link OpenFile#isWrittenTo()} returns {@code true}. Otherwise {@code false}.
+	 * @return {@code true} if and only if at least one dirty {@link OpenFile} exists. Otherwise {@code false}.
+	 * @see OpenFile#isDirty()
 	 */
-	public boolean hasWrittenToOpenFiles(){
-		return openFiles.entrySet().stream().anyMatch(entry -> entry.getValue().isWrittenTo());
+	boolean hastDirtyOpenFiles() {
+		return openFiles.entrySet().stream().anyMatch(entry -> entry.getValue().isDirty());
 	}
 
 	/**

--- a/src/main/java/org/cryptomator/frontend/fuse/OpenFileFactory.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/OpenFileFactory.java
@@ -68,13 +68,13 @@ public class OpenFileFactory implements AutoCloseable {
 	}
 
 	/**
-	 * Tests, if there exists dirty {@link OpenFile}s
-	 * This method is neither atomic regarding the set of open files nor regarding each open file individually. Therefore, external synchronization is required.
+	 * Tests, if any {@link OpenFile} is considered <em>dirty</em>, e.g. might have pending changes.
+	 * This method is neither atomic regarding the set of OpenFiles nor regarding each OpenFile individually. Therefore, external synchronization is required.
 	 *
 	 * @return {@code true} if and only if at least one dirty {@link OpenFile} exists. Otherwise {@code false}.
 	 * @see OpenFile#isDirty()
 	 */
-	boolean hastDirtyOpenFiles() {
+	boolean hasDirtyFiles() {
 		return openFiles.entrySet().stream().anyMatch(entry -> entry.getValue().isDirty());
 	}
 

--- a/src/main/java/org/cryptomator/frontend/fuse/OpenFileFactory.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/OpenFileFactory.java
@@ -67,8 +67,14 @@ public class OpenFileFactory implements AutoCloseable {
 		}
 	}
 
-	public int getOpenFileCount(){
-		return openFiles.size();
+	/**
+	 * Tests, if there exists {@link OpenFile}s, which has been written to.
+	 * The check performed in this method is not atomic and therefore requires external synchronization.
+	 *
+	 * @return {@code true} if and only if at least one {@link OpenFile} exists, where {@link OpenFile#isWrittenTo()} returns {@code true}. Otherwise {@code false}.
+	 */
+	public boolean hasWrittenToOpenFiles(){
+		return openFiles.entrySet().stream().anyMatch(entry -> entry.getValue().isWrittenTo());
 	}
 
 	/**

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
@@ -48,7 +48,6 @@ public sealed class ReadOnlyAdapter implements FuseNioAdapter permits ReadWriteA
 	private final ReadOnlyDirectoryHandler dirHandler;
 	private final ReadOnlyFileHandler fileHandler;
 	private final ReadOnlyLinkHandler linkHandler;
-	private final BooleanSupplier hasOpenFiles;
 
 	protected ReadOnlyAdapter(Errno errno, Path root, int maxFileNameLength, FileNameTranscoder fileNameTranscoder, FileStore fileStore, OpenFileFactory openFiles, ReadOnlyDirectoryHandler dirHandler, ReadOnlyFileHandler fileHandler) {
 		this.errno = errno;
@@ -61,7 +60,6 @@ public sealed class ReadOnlyAdapter implements FuseNioAdapter permits ReadWriteA
 		this.dirHandler = dirHandler;
 		this.fileHandler = fileHandler;
 		this.linkHandler = new ReadOnlyLinkHandler(fileNameTranscoder);
-		this.hasOpenFiles = () -> openFiles.getOpenFileCount() != 0;
 	}
 
 	public static ReadOnlyAdapter create(Errno errno, Path root, int maxFileNameLength, FileNameTranscoder fileNameTranscoder) {
@@ -305,7 +303,7 @@ public sealed class ReadOnlyAdapter implements FuseNioAdapter permits ReadWriteA
 	@Override
 	public boolean isInUse() {
 		try (PathLock pLock = lockManager.tryLockForWriting("/")) {
-			return hasOpenFiles.getAsBoolean();
+			return openFiles.hasWrittenToOpenFiles();
 		} catch (AlreadyLockedException e) {
 			return true;
 		}
@@ -320,7 +318,7 @@ public sealed class ReadOnlyAdapter implements FuseNioAdapter permits ReadWriteA
 	 * Attempts to get a specific error code that best describes the given exception.
 	 * As a side effect this logs the error.
 	 *
-	 * @param e An exception
+	 * @param e      An exception
 	 * @param opDesc A human-friendly string describing what operation was attempted (for logging purposes)
 	 * @return A specific error code or -EIO.
 	 */
@@ -331,8 +329,8 @@ public sealed class ReadOnlyAdapter implements FuseNioAdapter permits ReadWriteA
 //			LOG.warn("{} {} failed, name too long.", opDesc);
 //			return -ErrorCodes.ENAMETOOLONG();
 //		} else {
-			LOG.error(opDesc + " failed.", e);
-			return -errno.eio();
+		LOG.error(opDesc + " failed.", e);
+		return -errno.eio();
 //		}
 	}
 }

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
@@ -317,7 +317,7 @@ public sealed class ReadOnlyAdapter implements FuseNioAdapter permits ReadWriteA
 	 * Attempts to get a specific error code that best describes the given exception.
 	 * As a side effect this logs the error.
 	 *
-	 * @param e      An exception
+	 * @param e An exception
 	 * @param opDesc A human-friendly string describing what operation was attempted (for logging purposes)
 	 * @return A specific error code or -EIO.
 	 */
@@ -328,8 +328,8 @@ public sealed class ReadOnlyAdapter implements FuseNioAdapter permits ReadWriteA
 //			LOG.warn("{} {} failed, name too long.", opDesc);
 //			return -ErrorCodes.ENAMETOOLONG();
 //		} else {
-		LOG.error(opDesc + " failed.", e);
-		return -errno.eio();
+			LOG.error(opDesc + " failed.", e);
+			return -errno.eio();
 //		}
 	}
 }

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
@@ -302,7 +302,7 @@ public sealed class ReadOnlyAdapter implements FuseNioAdapter permits ReadWriteA
 	@Override
 	public boolean isInUse() {
 		try (PathLock pLock = lockManager.tryLockForWriting("/")) {
-			return openFiles.hastDirtyOpenFiles();
+			return openFiles.hasDirtyFiles();
 		} catch (AlreadyLockedException e) {
 			return true;
 		}

--- a/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/ReadOnlyAdapter.java
@@ -32,7 +32,6 @@ import java.nio.file.attribute.PosixFileAttributes;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
-import java.util.function.BooleanSupplier;
 
 public sealed class ReadOnlyAdapter implements FuseNioAdapter permits ReadWriteAdapter {
 
@@ -303,7 +302,7 @@ public sealed class ReadOnlyAdapter implements FuseNioAdapter permits ReadWriteA
 	@Override
 	public boolean isInUse() {
 		try (PathLock pLock = lockManager.tryLockForWriting("/")) {
-			return openFiles.hasWrittenToOpenFiles();
+			return openFiles.hastDirtyOpenFiles();
 		} catch (AlreadyLockedException e) {
 			return true;
 		}


### PR DESCRIPTION
This PR also mitigates problems described in #79, but with a different approach. Instead of timing based staleness of opened files, we determine if the filesystem is "in use", if at least one open file exists, which was written to.

The idea behind this approach is to allow regular unmounting as long as no data loss happens on the filesystem. If an open file was written to, we require it to be properly closed by a `release()` call to let `isInUse()` return `false`.
