### PR TITLE
Search for lib in `java.library.path` instead of hardcoded path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
         <!-- dependencies -->
         <integrations-api.version>1.3.0</integrations-api.version>
-        <jfuse.version>0.6.0</jfuse.version>
+        <jfuse.version>0.6.2</jfuse.version>
         <slf4j.version>2.0.7</slf4j.version>
         <caffeine.version>3.1.7</caffeine.version>
 

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/LinuxFuseMountProvider.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/LinuxFuseMountProvider.java
@@ -55,7 +55,7 @@ public class LinuxFuseMountProvider implements MountService {
 
 	@Override
 	public boolean isSupported() {
-		return Arrays.stream(LIB_PATHS).map(Path::of).anyMatch(Files::exists) && isFusermount3Installed();
+		return isFusermount3Installed();
 	}
 
 	private boolean isFusermount3Installed() {
@@ -115,9 +115,8 @@ public class LinuxFuseMountProvider implements MountService {
 			Objects.requireNonNull(mountPoint);
 			Objects.requireNonNull(mountFlags);
 
-			var libPath = Arrays.stream(LIB_PATHS).map(Path::of).filter(Files::exists).map(Path::toString).findAny().orElseThrow();
 			var builder = Fuse.builder();
-			builder.setLibraryPath(libPath);
+			Arrays.stream(LIB_PATHS).map(Path::of).filter(Files::exists).map(Path::toString).findAny().ifPresent(builder::setLibraryPath);
 			if (mountFlags.contains("-oallow_other") || mountFlags.contains("-oallow_root")) {
 				LOG.warn("Mounting with flag -oallow_other or -oallow_root. Ensure that in /etc/fuse.conf option user_allow_other is enabled.");
 			}

--- a/src/main/java/org/cryptomator/frontend/fuse/mount/LinuxFuseMountProvider.java
+++ b/src/main/java/org/cryptomator/frontend/fuse/mount/LinuxFuseMountProvider.java
@@ -40,7 +40,6 @@ public class LinuxFuseMountProvider implements MountService {
 	private static final Logger LOG = LoggerFactory.getLogger(LinuxFuseMountProvider.class);
 	private static final Path USER_HOME = Paths.get(System.getProperty("user.home"));
 	private static final String[] LIB_PATHS = {
-			"/usr/lib/libfuse3.so", // default
 			"/lib/x86_64-linux-gnu/libfuse3.so.3", // debian amd64
 			"/lib/aarch64-linux-gnu/libfuse3.so.3", // debian aarch64
 			"/usr/lib64/libfuse3.so.3", // fedora


### PR DESCRIPTION
Resolve #72 